### PR TITLE
Restoring geometry test configuration.

### DIFF
--- a/icarusalg/Geometry/dump_icarus_geometry.fcl
+++ b/icarusalg/Geometry/dump_icarus_geometry.fcl
@@ -1,0 +1,65 @@
+#
+# File:     dump_icarus_geometry.fcl
+# Purpouse: Job dumping ICARUS current geomerty into `ICARUS_geometry.txt` file.
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     May 30, 2018
+# Version:  1.0
+#
+# This job uses the "default" ICARUS geometry, as configured in the
+# `icarus_geometry_services` configuration table.
+#
+# Service dependencies:
+#  * Geometry service
+#  * message facility
+#
+
+#include "geometry_icarus.fcl"
+#include "messages_icarus.fcl"
+
+
+process_name: GeometryDump
+
+
+services: {
+  # use a specific configuration which dumps the geometry on a file.
+  message: {
+    destinations: {
+      GeometryLog: {
+        type: file
+        
+        filename:  "ICARUS-geometry.txt"
+        threshold:  INFO
+        categories: {
+          DumpGeometry: { limit: -1 }
+          default: { limit: 0 }
+        }
+      }
+      CriticalLog: {
+        type: cerr
+        threshold:  SYSTEM
+      }
+    #  LogDebugFile: @local::message_debugfile_icarus
+    } # destinations
+  } # message
+
+  @table::icarus_geometry_services
+  
+} # services
+
+
+physics: {
+  analyzers: {
+    geometrydump: {
+      module_type: DumpGeometry
+      
+      # message facility category for the output (default: "DumpGeometry")
+      outputCategory: "DumpGeometry"
+    }
+  } # analyzers
+
+  dumpers: [ geometrydump ]
+  
+  end_paths: [ dumpers ]
+  
+} # physics
+


### PR DESCRIPTION
From the commit message:
> It looks like `dump_geometry_icarus.fcl` it is not in `icaruscode` any more, either.
> Despite being an art configuration, it is used also by non-_art_ unit tests which extract the current geometry configuration out of it.
> The configuration of the equivalent _art_-based unit test and the non-_art_ unit tests are intentionally merged into this one file.