### PR TITLE
Update the default geometry

### DIFF
--- a/icarusalg/Geometry/geometry_icarus.fcl
+++ b/icarusalg/Geometry/geometry_icarus.fcl
@@ -287,8 +287,8 @@ icarus_split_induction_overburden_geometry: {
   @table::icarus_geometry_template
 
   Name: "icarus_splitwires"
-  GDML: "icarus_complete_20200709.gdml"
-  ROOT: "icarus_complete_20200709.gdml"
+  GDML: "icarus_complete_20201107.gdml"
+  ROOT: "icarus_complete_20201107.gdml"
 
   ChannelMapping: @local::icarus_split_induction_geometry_helper.Mapper
 
@@ -327,8 +327,8 @@ icarus_split_induction_nooverburden_geometry: {
   @table::icarus_geometry_template
 
   Name: "icarus_splitwires"
-  GDML: "icarus_complete_20200709_no_overburden.gdml"
-  ROOT: "icarus_complete_20200709_no_overburden.gdml"
+  GDML: "icarus_complete_20201107_no_overburden.gdml"
+  ROOT: "icarus_complete_20201107_no_overburden.gdml"
 
   ChannelMapping: @local::icarus_split_induction_geometry_helper.Mapper
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -36,7 +36,7 @@ product             version
 larsoftobj          v09_03_00
 guideline_sl        v2_0_0
 
-cetbuildtools	    v7_17_01	-	only_for_build
+cetbuildtools	    v7_15_01	-	only_for_build
 end_product_list
 
 # Restore this temporarily...


### PR DESCRIPTION
This changes the default geometry from the version developed in July of 2020 to the updated version of November 2020 which includes an offset for the TPCs to reflect their actual position as well as updates for the PMT system. 