### PR TITLE
Geometry version name set to icarus_v2

### DIFF
--- a/icarusalg/Geometry/geometry_icarus.fcl
+++ b/icarusalg/Geometry/geometry_icarus.fcl
@@ -80,7 +80,7 @@ BEGIN_PROLOG
 
 icarus_geometry_template: {
   SurfaceY:        6.9e2    # in cm, vertical distance to the surface
-  Name:            "icarus"
+  Name:            "icarus_v2" # see ICARUS wiki for a list
   DisableWiresInG4: true
 } # icarus_geometry_template
 
@@ -288,7 +288,7 @@ icarus_split_induction_geometry_helper: {
 icarus_split_induction_overburden_geometry: {
   @table::icarus_geometry_template
 
-  Name: "icarus_splitwires"
+  Name: "icarus_v2"
   GDML: "icarus_complete_20210311_rotUV.gdml"
   ROOT: "icarus_complete_20210311_rotUV.gdml"
 
@@ -329,7 +329,7 @@ icarus_split_induction_overburden_geometry_services: {
 icarus_split_induction_nooverburden_geometry: {
   @table::icarus_geometry_template
 
-  Name: "icarus_splitwires"
+  Name: "icarus_v2"
   GDML: "icarus_complete_20210311_no_overburden_rotUV.gdml"
   ROOT: "icarus_complete_20210311_no_overburden_rotUV.gdml"
 

--- a/icarusalg/Geometry/geometry_icarus.fcl
+++ b/icarusalg/Geometry/geometry_icarus.fcl
@@ -47,7 +47,15 @@
 #         detector without concrete overburden
 #     * `icarus_split_induction_geometry_services`: the default geometry in
 #         this category
-#
+# * `icarus_geometry_services_legacy_icarus_splitwires`: legacy geometry
+#   configuration for samples simulated with icaruscode earlier than v09_18_00,
+#   with no overburden; also related:
+#     * `icarus_geometry_services_overburden_legacy_icarus_splitwires`
+#       (added 3-m concrete overburden)
+#     * `icarus_geometry_services_no_overburden_legacy_icarus_splitwires`
+#       (with no 3-m concrete overburden: as the default)
+#   
+# 
 # Since the documentation is often not updated, check the definitions below
 # to see which are the current defaults.
 #
@@ -357,7 +365,7 @@ icarus_split_induction_nooverburden_geometry_services: {
 ###
 ### Override a geometry configuration by:
 ###
-###     services: {icarus_legacy_services_v08_05_00
+###     services: {
 ###       @table::services
 ###       @table::icarus_split_induction_geometry_services
 ###     }
@@ -462,6 +470,32 @@ icarus_geometry: @local::icarus_geometry_services.Geometry
 icarus_geo:      @local::icarus_geometry # backward compatibility
 
 icarus_geometry_helper:  @local::icarus_geometry_services.ExptGeoHelperInterface
+
+
+################################################################################
+###  Legacy configurations
+################################################################################
+###
+### icarus_geometry_services_legacy_icarus_splitwires:
+###   geometry tagged as `icarus_splitwires` for samples produced with v09_17_02
+###   and earlier
+### 
+### Also versions with explicit overburden specification.
+###
+icarus_geometry_services_no_overburden_legacy_icarus_splitwires: 
+  @local::icarus_split_induction_nooverburden_geometry_services
+icarus_geometry_services_no_overburden_legacy_icarus_splitwires.Geometry.Name: icarus_splitwires
+icarus_geometry_services_no_overburden_legacy_icarus_splitwires.Geometry.GDML: "icarus_complete_20201107_no_overburden.gdml"
+icarus_geometry_services_no_overburden_legacy_icarus_splitwires.Geometry.ROOT: "icarus_complete_20201107_no_overburden.gdml"
+
+icarus_geometry_services_overburden_legacy_icarus_splitwires: 
+  @local::icarus_split_induction_nooverburden_geometry_services
+icarus_geometry_services_overburden_legacy_icarus_splitwires.Geometry.Name: icarus_splitwires
+icarus_geometry_services_overburden_legacy_icarus_splitwires.Geometry.GDML: "icarus_complete_20201107.gdml"
+icarus_geometry_services_overburden_legacy_icarus_splitwires.Geometry.ROOT: "icarus_complete_20201107.gdml"
+
+icarus_geometry_services_legacy_icarus_splitwires:
+  @local::icarus_geometry_services_no_overburden_legacy_icarus_splitwires
 
 
 ################################################################################


### PR DESCRIPTION
The geometry `Name` is now set to `icarus_v2`.
This formalises the breaking change which happened in v09_18_00.
Neutralise the check by `services.Geometry.SkipConfigurationCheck: true` if needed.
Details on the geometry are in [ICARUS wiki](https://sbnsoftware.github.io/icaruscode_wiki/Detector_geometry.html).

> **Note** This means that samples generated with `v09_18_00` and `v09_18_00_01` will trigger this check and will _require_ it to be disabled.

# New legacy configurations

The geometry configuration presets `icarus_geometry_services_legacy_icarus_splitwires`, `icarus_geometry_services_overburden_legacy_icarus_splitwires` and `icarus_geometry_services_no_overburden_legacy_icarus_splitwires` have been added to process pre-`v09_18_00` samples.
The error message that appears when the legacy configuration is _not_ used to process such samples is like:
```
---- EventProcessorFailure BEGIN
  EventProcessor: an exception occurred during current event processing
  ---- Geometry BEGIN
    Geometry used for run run: 7 is incompatible with the one configured in the job!
    === job configuration ==================================================
    Geometry information version: 2
    Detector name:               'icarus_v2'
    Full configuration:
    --------------------------------------------------------------------------------
    ChannelMapping: {
       WirelessChannels: {
          CollectionEvenPostChannels: 96
          CollectionEvenPreChannels: 64
          CollectionOddPostChannels: 64
          CollectionOddPreChannels: 96
          FirstInductionPostChannels: 96
          FirstInductionPreChannels: 0
          SecondInductionEvenPostChannels: 64
          SecondInductionEvenPreChannels: 96
          SecondInductionOddPostChannels: 96
          SecondInductionOddPreChannels: 64
       }
       tool_type: "ICARUSsplitInductionChannelMapSetupTool"
    }
    DisableWiresInG4: true
    GDML: "icarus_complete_20210311_no_overburden_rotUV.gdml"
    Name: "icarus_v2"
    ROOT: "icarus_complete_20210311_no_overburden_rotUV.gdml"
    SurfaceY: 690
    service_type: "Geometry"
    
    --------------------------------------------------------------------------------
    === run configuration ==================================================
    Geometry information version: 1
    Detector name:               'icarus_splitwires'
    ========================================================================
  ---- Geometry END
---- EventProcessorFailure END
```
(for a `v09_09_02` sample; newer samples will sport a more detailed configuration dump).
