### PR TITLE
Added utility to compact integer sequences for printing.

### DIFF
--- a/icarusalg/Utilities/IntegerRanges.h
+++ b/icarusalg/Utilities/IntegerRanges.h
@@ -1,0 +1,447 @@
+/**
+ * @file   icarusalg/Utilities/IntegerRanges.h
+ * @brief  Class compacting a list of integers.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   May 18, 2021
+ * 
+ * This is a header-only, pure standard C++ library.
+ */
+
+
+#ifndef ICARUSALG_UTILITIES_INTEGERRANGES_H
+#define ICARUSALG_UTILITIES_INTEGERRANGES_H
+
+// C/C++ standard libraries
+#include <ostream>
+#include <vector>
+#include <initializer_list>
+#include <numeric> // std::accumulate()
+#include <stdexcept> // std::runtime_error
+#include <type_traits> // std::is_integral_v
+
+
+// -----------------------------------------------------------------------------
+namespace icarus {
+  
+  // ---------------------------------------------------------------------------
+  namespace details {
+    
+    template <typename T = int> class IntegerRangesBase;
+    
+    template <typename T>
+    std::ostream& operator<< (
+      std::ostream& out,
+      typename IntegerRangesBase<T>::Data_t const& range
+      );
+    
+  } // namespace details
+  // ---------------------------------------------------------------------------
+  
+  
+  template <typename T = int, bool CheckGrowing = false> class IntegerRanges;
+  
+  template <bool CheckGrowing = true, typename Coll>
+  IntegerRanges<typename Coll::value_type, CheckGrowing> makeIntegerRanges
+    (Coll const& coll);
+
+
+  template <typename T, bool CheckGrowing>
+  std::ostream& operator<<
+    (std::ostream& out, IntegerRanges<T, CheckGrowing> const& ranges);
+  
+} // namespace icarus
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief A sequence of contiguous ranges of integral numbers.
+ * @tparam T type of the integral numbers
+ * @tparam CheckGrowing if `true`, checks will be performed on construction
+ * 
+ * This class parses a sequence in input grouping the consecutive elements.
+ * The current interface is very simple, allowing only for query of groups
+ * ("ranges") and printing to a stream.
+ * The input is required and assumed to be a monotonously growing sequence,
+ * with the exception that duplicate consecutive entries are allowed
+ * (and ignored).
+ * 
+ * Each range is stored as a semi-open interval: [ _lower_, _upper_ [.
+ */
+template <typename T /* = int */>
+class icarus::details::IntegerRangesBase {
+  static_assert
+    (std::is_integral_v<T>, "IntegerRanges only support integral types.");
+  
+    public:
+  using Data_t = T; ///< Type of data for the range set.
+  
+  struct Range_t {
+    
+    Data_t lower {};
+    Data_t upper {};
+    
+    constexpr Range_t() noexcept = default;
+    constexpr Range_t(Data_t lower, Data_t upper) noexcept;
+    
+    constexpr bool empty() const noexcept;
+    constexpr std::size_t size() const noexcept;
+    constexpr bool isOne() const noexcept;
+    constexpr bool isTwo() const noexcept;
+    
+    void dump(
+      std::ostream& out,
+      std::string const& sep, std::string const& simpleSep
+      ) const;
+    void dump(std::ostream& out, std::string const& sep = "--") const;
+    
+  }; // struct Range_t
+  
+  
+  /// Removes all the entries and makes the set as default-constructed.
+  void clear() noexcept;
+  
+  
+  // --- BEGIN -- Queries ------------------------------------------------------
+  /// @name Queries
+  /// @{
+  
+  /// Returns whether there is any element in the range set.
+  bool empty() const noexcept;
+  
+  /// Returns the number of elements in the ranges (gaps excluded).
+  std::size_t size() const noexcept;
+  
+  /// Returns the number of non-contiguous ranges in the set.
+  std::size_t nRanges() const noexcept;
+  
+  /// Returns an iterable object with all sorted ranges as elements.
+  decltype(auto) ranges() const noexcept;
+  
+  /// @}
+  // --- END ---- Queries ------------------------------------------------------
+  
+  
+  /// Prints the range into the specified stream.
+  /// @param out the stream to print into
+  /// @param sep separator between ranges
+  /// @param inRangeSep separator between lower and higher limit of each range
+  void dump(std::ostream& out,
+    std::string const& sep = " ", std::string const& inRangeSep = "--"
+    ) const;
+  
+  
+    protected:
+  
+  /// Default constructor: starts with no elements.
+  IntegerRangesBase() = default;
+  
+  /// Constructor for the derived classes.
+  IntegerRangesBase(std::vector<Range_t> ranges);
+  
+  
+  /// Fills the ranges.
+  template <bool CheckGrowing, typename BIter, typename EIter>
+  static std::vector<Range_t> compactRange(BIter b, EIter e);
+  
+  
+  /// Returns `value` incremented by 1.
+  static constexpr Data_t plusOne(Data_t value) noexcept;
+  
+  /// Returns `value` decremented by 1.
+  static constexpr Data_t minusOne(Data_t value) noexcept;
+  
+    private:
+  
+  std::vector<Range_t> fRanges; ///< List of current ranges.
+  
+  
+}; // class icarus::details::IntegerRangesBase<>
+
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief A sequence of contiguous ranges of integral numbers.
+ * @tparam T type of the integral numbers
+ * @tparam CheckGrowing if `true`, checks will be performed on construction
+ * 
+ * This class parses a sequence in input grouping the consecutive elements.
+ * The current interface is very simple, allowing only for query of groups
+ * ("ranges") and printing to a stream.
+ * The input is required and assumed to be a monotonously growing sequence,
+ * with the exception that duplicate consecutive entries are allowed
+ * (and ignored).
+ * 
+ * Each range is stored as a semi-open interval: [ _lower_, _upper_ [.
+ * 
+ * If `CheckGrowing` is `true`, on input an exception will be thrown if the
+ * input is not strictly sorted (but duplicate elements are still allowed).
+ * 
+ * Example of usage:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * std::array data { 1, 2, 4, 5, 6, 8, 10 };
+ * 
+ * icarus::IntegerRanges ranges { data };
+ * std::cout << "Ranges: " << ranges << std::endl;
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * will print something like `Ranges: 1 2 4--6 8 10`.
+ * 
+ */
+template <typename T /* = int */, bool CheckGrowing /* = false */>
+class icarus::IntegerRanges: public icarus::details::IntegerRangesBase<T> {
+  
+  using Base_t = icarus::details::IntegerRangesBase<T>;
+  
+    public:
+  static constexpr bool IsChecked = CheckGrowing;
+  
+  using Data_t = typename Base_t::Data_t;
+  
+  /// Default constructor: an empty set of ranges.
+  IntegerRanges() = default;
+  
+  /// Constructor: range from the values pointed between `b` and `e` iterators.
+  template <typename BIter, typename EIter>
+  IntegerRanges(BIter b, EIter e);
+  
+  IntegerRanges(std::initializer_list<Data_t> data);
+  
+}; // class icarus::IntegerRanges<>
+
+
+// -----------------------------------------------------------------------------
+/// Returns a `IntegerRanges` object from the elements in `coll`.
+template <bool CheckGrowing = true, typename Coll>
+auto icarus::makeIntegerRanges(Coll const& coll)
+  -> IntegerRanges<typename Coll::value_type, CheckGrowing>
+{
+  return IntegerRanges<typename Coll::value_type, CheckGrowing>
+    { begin(coll), end(coll) };
+} // icarus::makeIntegerRanges(Coll const& coll)
+
+
+
+// -----------------------------------------------------------------------------
+// --- template implementation
+// -----------------------------------------------------------------------------
+// --- icarus::details::IntegerRangesBase<>::Range_t
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+constexpr icarus::details::IntegerRangesBase<T>::Range_t::Range_t
+  (Data_t lower, Data_t upper) noexcept
+  : lower(lower), upper(upper)
+  {}
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+constexpr bool icarus::details::IntegerRangesBase<T>::Range_t::empty
+  () const noexcept
+  { return lower == upper; }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+constexpr std::size_t icarus::details::IntegerRangesBase<T>::Range_t::size
+  () const noexcept
+  { return upper - lower; }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+constexpr bool icarus::details::IntegerRangesBase<T>::Range_t::isOne
+  () const noexcept
+  { return plusOne(lower) == upper; }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+constexpr bool icarus::details::IntegerRangesBase<T>::Range_t::isTwo
+  () const noexcept
+  { return plusOne(lower) == minusOne(upper); }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+void icarus::details::IntegerRangesBase<T>::Range_t::dump
+  (std::ostream& out, std::string const& sep, std::string const& simpleSep)
+  const
+{
+  
+  if (empty()) {
+    // let's say we don't print nothing at all
+    return;
+  }
+  
+  out << lower;
+  if (isOne()) return;
+  
+  out << (isTwo()? simpleSep: sep) << icarus::details::IntegerRangesBase<T>::minusOne(upper);
+  return;
+  
+} // icarus::details::IntegerRangesBase<>::Range_t::dump()
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+void icarus::details::IntegerRangesBase<T>::Range_t::dump
+  (std::ostream& out, std::string const& sep /* = "--" */) const
+  { dump(out, sep, sep); }
+
+
+// -----------------------------------------------------------------------------
+// --- icarus::details::IntegerRangesBase<>
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+icarus::details::IntegerRangesBase<T>::IntegerRangesBase
+  (std::vector<Range_t> ranges): fRanges(std::move(ranges))
+  {}
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+void icarus::details::IntegerRangesBase<T>::clear() noexcept
+  { return fRanges.clear(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+bool icarus::details::IntegerRangesBase<T>::empty() const noexcept
+  { return fRanges.empty(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+std::size_t icarus::details::IntegerRangesBase<T>::size() const noexcept {
+  
+  return std::accumulate(fRanges.begin(), fRanges.end(), 0U, 
+    [](std::size_t s, Range_t const& r){ return s + r.size(); });
+  
+} // icarus::details::IntegerRangesBase<>::size()
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+std::size_t icarus::details::IntegerRangesBase<T>::nRanges() const noexcept
+  { return fRanges.size(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+decltype(auto) icarus::details::IntegerRangesBase<T>::ranges() const noexcept
+  { return fRanges; }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+template <bool CheckGrowing, typename BIter, typename EIter>
+auto icarus::details::IntegerRangesBase<T>::compactRange(BIter b, EIter e)
+  -> std::vector<Range_t>
+{
+  if (b == e) return {};
+  
+  std::vector<Range_t> ranges;
+  
+  auto it = b;
+  auto iPrev = it; // not sure if BIter default-constructible, so copy instead
+  auto iFirst = b;
+  
+  while (it != e) {
+    
+    iPrev = it++;
+    
+    if (it != e) { // check current and previous elements
+      if (*iPrev == *it) continue; // duplicate entry: quietly skip
+      if constexpr (CheckGrowing) {
+        if (*it < *iPrev) {
+          using std::to_string;
+          throw std::runtime_error{ "icarus::IntegerRanges"
+            " initialized with non-monotonically growing sequence ("
+            + to_string(*iPrev) + " then " + to_string(*it)
+            + ")"
+            };
+        }
+      } // if checking growth
+    } // if not at the end
+    
+    auto const nextExpected = plusOne(*iPrev);
+    
+    if ((it != e) && (*it == nextExpected)) continue; // contiguous to previous
+    
+    ranges.emplace_back(*iFirst, nextExpected);
+    
+    iFirst = it;
+    
+  } // while
+  
+  return ranges;
+} // icarus::details::IntegerRangesBase<>::compactRange()
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+constexpr auto icarus::details::IntegerRangesBase<T>::plusOne
+  (Data_t value) noexcept -> Data_t
+  { return ++value; }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+constexpr auto icarus::details::IntegerRangesBase<T>::minusOne
+  (Data_t value) noexcept -> Data_t
+  { return --value; }
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */>
+void icarus::details::IntegerRangesBase<T>::dump(
+  std::ostream& out,
+  std::string const& sep /* = " " */,
+  std::string const& inRangeSep /* = "--" */
+) const {
+  
+  if (empty()) return;
+  
+  auto iRange = fRanges.begin();
+  auto const rend = fRanges.end();
+  iRange->dump(out, inRangeSep, sep);
+  while (++iRange != rend) iRange->dump(out << sep, inRangeSep, sep);
+  
+} // icarus::details::IntegerRangesBase<>::dump()
+
+
+// -----------------------------------------------------------------------------
+// --- icarus::IntegerRanges<>
+// -----------------------------------------------------------------------------
+template <typename T /* = int */, bool CheckGrowing /* = true */>
+template <typename BIter, typename EIter>
+icarus::IntegerRanges<T, CheckGrowing>::IntegerRanges(BIter b, EIter e)
+  : Base_t{ Base_t::template compactRange<CheckGrowing>(b, e) }
+  {}
+
+
+// -----------------------------------------------------------------------------
+template <typename T /* = int */, bool CheckGrowing /* = true */>
+icarus::IntegerRanges<T, CheckGrowing>::IntegerRanges
+  (std::initializer_list<Data_t> data)
+  : IntegerRanges(data.begin(), data.end()) {}
+
+
+// -----------------------------------------------------------------------------
+template <typename T, bool CheckGrowing>
+std::ostream& icarus::operator<<
+  (std::ostream& out, typename IntegerRanges<T, CheckGrowing>::Range_t const& r)
+  { r.dump(out); return out; }
+
+
+// -----------------------------------------------------------------------------
+template <typename T, bool CheckGrowing>
+std::ostream& icarus::operator<<
+  (std::ostream& out, IntegerRanges<T, CheckGrowing> const& r)
+  { r.dump(out); return out; }
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSALG_UTILITIES_INTEGERRANGES_H

--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -13,6 +13,7 @@ cet_test(FastAndPoorGauss_test
 cet_test(SampledFunction_test USE_BOOST_UNIT)
 
 cet_test(FixedBins_test USE_BOOST_UNIT)
+cet_test(IntegerRanges_test USE_BOOST_UNIT)
 
 cet_test(NonRandomCounter_test
   LIBRARIES

--- a/test/Utilities/IntegerRanges_test.cc
+++ b/test/Utilities/IntegerRanges_test.cc
@@ -1,0 +1,286 @@
+/**
+ * @file   IntegerRanges_test.cc
+ * @brief  Unit test for `IntegerRanges` class.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   May 18, 2021
+ * @see    icarusalg/Utilities/IntegerRanges.h
+ */
+
+
+// Boost libraries
+#define BOOST_TEST_MODULE IntegerRanges
+#include <cetlib/quiet_unit_test.hpp> // BOOST_AUTO_TEST_CASE()
+#include <boost/test/test_tools.hpp> // BOOST_CHECK(), BOOST_CHECK_EQUAL(), ...
+
+// ICARUS libraries
+#include "icarusalg/Utilities/IntegerRanges.h"
+
+// LArSoft libraries
+#include "larcorealg/CoreUtils/enumerate.h"
+
+// C/C++ standard libraries
+#include <iostream>
+#include <utility> // std::pair<>
+#include <array>
+#include <type_traits> // std::is_same_v, std::remove_reference_t
+
+
+// -----------------------------------------------------------------------------
+template <typename Cont>
+std::size_t count(Cont const& cont)
+  { return std::distance(begin(cont), end(cont)); }
+
+
+// -----------------------------------------------------------------------------
+void TestConstDefaultConstructed() {
+  
+  icarus::IntegerRanges<int> const ranges;
+  
+  BOOST_CHECK(ranges.empty());
+  BOOST_CHECK_EQUAL(ranges.size(), 0U);
+  BOOST_CHECK_EQUAL(ranges.nRanges(), 0U);
+  BOOST_CHECK_EQUAL(count(ranges.ranges()), 0U);
+  
+} // TestConstDefaultConstructed()
+
+
+// -----------------------------------------------------------------------------
+void TestDefaultConstructed() {
+  
+  icarus::IntegerRanges<int> ranges;
+  
+  BOOST_CHECK(ranges.empty());
+  BOOST_CHECK_EQUAL(ranges.size(), 0U);
+  BOOST_CHECK_EQUAL(ranges.nRanges(), 0U);
+  BOOST_CHECK_EQUAL(count(ranges.ranges()), 0U);
+  
+  ranges.clear();
+  BOOST_CHECK(ranges.empty());
+  BOOST_CHECK_EQUAL(ranges.size(), 0U);
+  BOOST_CHECK_EQUAL(ranges.nRanges(), 0U);
+  BOOST_CHECK_EQUAL(count(ranges.ranges()), 0U);
+  
+} // TestDefaultConstructed()
+
+
+// -----------------------------------------------------------------------------
+void TestInitializerList() {
+  
+  
+  std::array const test { 1, 2, 3, 4, 6, 7, 8, 10, 11 };
+  std::array<std::pair<int, int>, 3U> const groups = {
+    std::pair{ 1, 5 },
+    std::pair{ 6, 9 },
+    std::pair{ 10, 12 }
+  };
+  
+  
+  icarus::IntegerRanges ranges { 1, 2, 3, 4, 6, 7, 8, 10, 11 };
+  std::cout << "Testing: " << ranges << std::endl;
+  
+  BOOST_CHECK_EQUAL(ranges.empty(), test.empty());
+  BOOST_CHECK_EQUAL(ranges.size(), test.size());
+  BOOST_CHECK_EQUAL(ranges.nRanges(), groups.size());
+  
+  auto const& rangeContent = ranges.ranges();
+  for (auto const& [ i, r, e ]: util::enumerate(rangeContent, groups)) {
+    BOOST_TEST_MESSAGE("[" << i << "]");
+    BOOST_CHECK_EQUAL(r.lower, e.first);
+    BOOST_CHECK_EQUAL(r.upper, e.second);
+  } // for
+  
+} // TestInitializerList()
+
+
+// -----------------------------------------------------------------------------
+void TestCollection() {
+  
+  
+  std::array const test { 1, 2, 3, 4, 6, 7, 8, 10, 11 };
+  std::array<std::pair<int, int>, 3U> const groups = {
+    std::pair{ 1, 5 },
+    std::pair{ 6, 9 },
+    std::pair{ 10, 12 }
+  };
+  
+  
+  auto const ranges = icarus::makeIntegerRanges(test);
+  static_assert(std::is_same_v<
+    std::remove_reference_t<decltype(ranges)>,
+    icarus::IntegerRanges<int, true> const
+    >);
+  std::cout << "Testing: " << ranges << std::endl;
+  
+  BOOST_CHECK_EQUAL(ranges.empty(), test.empty());
+  BOOST_CHECK_EQUAL(ranges.size(), test.size());
+  BOOST_CHECK_EQUAL(ranges.nRanges(), groups.size());
+  
+  auto const& rangeContent = ranges.ranges();
+  for (auto const& [ i, r, e ]: util::enumerate(rangeContent, groups)) {
+    BOOST_TEST_MESSAGE("[" << i << "]");
+    BOOST_CHECK_EQUAL(r.lower, e.first);
+    BOOST_CHECK_EQUAL(r.upper, e.second);
+  } // for
+  
+} // TestCollection()
+
+
+// -----------------------------------------------------------------------------
+void TestSparse() {
+  
+  
+  std::array const test { 1, 2, 3, 4, 6, 7, 8, 10, 11 };
+  std::array<std::pair<int, int>, 3U> const groups = {
+    std::pair{ 1, 5 },
+    std::pair{ 6, 9 },
+    std::pair{ 10, 12 }
+  };
+  
+  
+  icarus::IntegerRanges ranges { test.begin(), test.end() };
+  std::cout << "Testing: " << ranges << std::endl;
+  
+  BOOST_CHECK_EQUAL(ranges.empty(), test.empty());
+  BOOST_CHECK_EQUAL(ranges.size(), test.size());
+  BOOST_CHECK_EQUAL(ranges.nRanges(), groups.size());
+  
+  auto const& rangeContent = ranges.ranges();
+  for (auto const& [ i, r, e ]: util::enumerate(rangeContent, groups)) {
+    BOOST_TEST_MESSAGE("[" << i << "]");
+    BOOST_CHECK_EQUAL(r.lower, e.first);
+    BOOST_CHECK_EQUAL(r.upper, e.second);
+  } // for
+  
+} // TestSparse()
+
+
+// -----------------------------------------------------------------------------
+void TestSingles() {
+  
+  
+  std::array const test { 1, 3, 6, 7, 8, 11 };
+  std::array<std::pair<int, int>, 4U> const groups = {
+    std::pair{ 1, 2 },
+    std::pair{ 3, 4 },
+    std::pair{ 6, 9 },
+    std::pair{ 11, 12 }
+  };
+  
+  
+  icarus::IntegerRanges ranges { test.begin(), test.end() };
+  std::cout << "Testing: " << ranges << std::endl;
+  
+  BOOST_CHECK_EQUAL(ranges.empty(), test.empty());
+  BOOST_CHECK_EQUAL(ranges.size(), test.size());
+  BOOST_CHECK_EQUAL(ranges.nRanges(), groups.size());
+  
+  auto const& rangeContent = ranges.ranges();
+  for (auto const& [ i, r, e ]: util::enumerate(rangeContent, groups)) {
+    BOOST_TEST_MESSAGE("[" << i << "]");
+    BOOST_CHECK_EQUAL(r.lower, e.first);
+    BOOST_CHECK_EQUAL(r.upper, e.second);
+  } // for
+  
+} // TestSingles()
+
+
+// -----------------------------------------------------------------------------
+void TestDuplicates() {
+  
+  std::array const test { 1, 1, 3, 6, 6, 6, 7, 8, 11, 11 };
+  std::array<std::pair<int, int>, 4U> const groups = {
+    std::pair{ 1, 2 },
+    std::pair{ 3, 4 },
+    std::pair{ 6, 9 },
+    std::pair{ 11, 12 }
+  };
+  
+  
+  icarus::IntegerRanges ranges { test.begin(), test.end() };
+  std::cout << "Testing: " << ranges << std::endl;
+  
+  BOOST_CHECK_EQUAL(ranges.empty(), test.empty());
+  BOOST_CHECK_EQUAL(ranges.size(), test.size() - 4U); // account for duplicates
+  BOOST_CHECK_EQUAL(ranges.nRanges(), groups.size());
+  
+  auto const& rangeContent = ranges.ranges();
+  for (auto const& [ i, r, e ]: util::enumerate(rangeContent, groups)) {
+    BOOST_TEST_MESSAGE("[" << i << "]");
+    BOOST_CHECK_EQUAL(r.lower, e.first);
+    BOOST_CHECK_EQUAL(r.upper, e.second);
+  } // for
+  
+} // TestDuplicates()
+
+
+// -----------------------------------------------------------------------------
+void TestUnsorted() {
+  
+  std::array const test { 1, 3, 7, 8, 8, 6, 11 };
+  
+  BOOST_CHECK_THROW(
+    (icarus::IntegerRanges<int, true>{ test.begin(), test.end() }),
+    std::runtime_error
+    );
+  
+  // technically, the following is also allowed to throw (not guaranteed to)
+  BOOST_CHECK_NO_THROW(
+    (icarus::IntegerRanges<int, false>{ test.begin(), test.end() })
+    );
+  
+} // TestDuplicates()
+
+
+//------------------------------------------------------------------------------
+void TestIntegerRangesDocumentation() {
+  
+  /*
+   * The promise:
+   * 
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * std::array data { 1, 2, 4, 5, 6, 8, 10 };
+   * 
+   * IntegerRanges ranges { data };
+   * std::cout << "Ranges: " << ranges << std::endl;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * will print something like `Ranges: 1 2 4--6 8 10`.
+   */
+   
+  std::array data { 1, 2, 4, 5, 5, 6, 8, 10 };
+  
+  icarus::IntegerRanges ranges { icarus::makeIntegerRanges(data) };
+  std::cout << "Ranges: " << ranges << std::endl;
+  
+  // ----------------------------------------------------------------------------
+  std::stringstream sstr;
+  sstr << "Ranges: " << ranges;
+  BOOST_CHECK_EQUAL(sstr.str(), "Ranges: 1 2 4--6 8 10");
+  
+} // TestIntegerRangesDocumentation()
+
+
+//------------------------------------------------------------------------------
+//---  The tests
+//---
+BOOST_AUTO_TEST_CASE( BasicTestCase ) {
+  
+  TestConstDefaultConstructed();
+  TestDefaultConstructed();
+  TestInitializerList();
+  TestCollection();
+  TestSparse();
+  TestSingles();
+  TestDuplicates();
+  TestUnsorted();
+  
+} // BOOST_AUTO_TEST_CASE( BasicTestCase )
+
+
+BOOST_AUTO_TEST_CASE( DocumentationTestCase ) {
+  
+  TestIntegerRangesDocumentation();
+  
+} // BOOST_AUTO_TEST_CASE( DocumentationTestCase )
+
+
+//------------------------------------------------------------------------------


### PR DESCRIPTION
For example, `{ 1, 3, 4, 5, 7, 8 }` prints as `1 3--5 7 8` (you would do that with `std::cout << icarus::makeIntegerRanges(v)` with `v` the _sorted_ collection of numbers).

Name is `icarus::IntegerRanges` (and `icarus::makeIntegerRanges()`), it's Doxygen-documented and unit-tested.
It's feature-poor so far — e.g. elements can't be added or removed, and it does not even have an iterator.
Expandable upon request.

Also eligible for `sbncode` if desired.