### PR TITLE
c7:prof build cleanup

### DIFF
--- a/icarusalg/Utilities/BinaryDumpUtils.h
+++ b/icarusalg/Utilities/BinaryDumpUtils.h
@@ -193,7 +193,8 @@ namespace icarus::ns::util::details {
   template <typename Atom>
   std::ostream& operator<< (std::ostream& out, HexDumper<Atom> const& data);
 
-
+  template <typename T>
+  std::ostream& operator<< (std::ostream& out, ZeroPadder<T> const& data);
 } // namespace icarus::ns::util::details
 
 
@@ -383,7 +384,7 @@ void icarus::ns::util::details::printHex(std::ostream& out, T value) {
 
 
 // -----------------------------------------------------------------------------
-template <unsigned int N, char C = ' '>
+template <unsigned int N, char C >
 std::ostream& icarus::ns::util::details::operator<<
   (std::ostream& out, Blanks<N, C>)
 {

--- a/icarusalg/Utilities/BinaryDumpUtils.h
+++ b/icarusalg/Utilities/BinaryDumpUtils.h
@@ -193,6 +193,7 @@ namespace icarus::ns::util::details {
   template <typename Atom>
   std::ostream& operator<< (std::ostream& out, HexDumper<Atom> const& data);
 
+  /// Dumps a value padding with `0` via `ZeroPadder` wrapper.
   template <typename T>
   std::ostream& operator<< (std::ostream& out, ZeroPadder<T> const& data);
 } // namespace icarus::ns::util::details

--- a/icarusalg/Utilities/IntegerRanges.h
+++ b/icarusalg/Utilities/IntegerRanges.h
@@ -40,7 +40,7 @@ namespace icarus {
   
   template <typename T = int, bool CheckGrowing = false> class IntegerRanges;
   
-  template <bool CheckGrowing = true, typename Coll>
+  template <bool CheckGrowing = true , typename Coll>
   IntegerRanges<typename Coll::value_type, CheckGrowing> makeIntegerRanges
     (Coll const& coll);
 
@@ -49,6 +49,9 @@ namespace icarus {
   std::ostream& operator<<
     (std::ostream& out, IntegerRanges<T, CheckGrowing> const& ranges);
   
+  template <typename T, bool CheckGrowing>
+  std::ostream& operator<<
+    (std::ostream& out, typename IntegerRanges<T, CheckGrowing>::Range_t const& r);
 } // namespace icarus
 
 
@@ -211,7 +214,7 @@ class icarus::IntegerRanges: public icarus::details::IntegerRangesBase<T> {
 
 // -----------------------------------------------------------------------------
 /// Returns a `IntegerRanges` object from the elements in `coll`.
-template <bool CheckGrowing = true, typename Coll>
+template <bool CheckGrowing, typename Coll>
 auto icarus::makeIntegerRanges(Coll const& coll)
   -> IntegerRanges<typename Coll::value_type, CheckGrowing>
 {


### PR DESCRIPTION
1)Declare one of operator<< defenitions in icarus namespace in both ( IntegerRange.h and BinaryDumpUnits.h)
2)In both files changed redefenition of the template parameter