### PR TITLE
Update electron lifetime to a value closer to data for upcoming MCP

### DIFF
--- a/fcl/services/detectorproperties_icarus.fcl
+++ b/fcl/services/detectorproperties_icarus.fcl
@@ -7,7 +7,7 @@ icarus_detproperties: {
   
   ElectronsToADC:            1.208041e-3     # in ADC/e; 6241.5 electrons = 1fC
   Temperature:               87.5
-  Electronlifetime:          10000
+  Electronlifetime:          3500
   Efield:                    [0.5,0.733,0.933 ] #kV/cm to first,second,third wire planes
   
   SternheimerA:              0.1956           # Ar Sternheimer parameter a.


### PR DESCRIPTION
I picked out 3.5ms -- does this seem reasonable?