### PR TITLE
Enabled beam gate information in detector clocks service for data

### DIFF
--- a/fcl/services/detectorclocks_icarus.fcl
+++ b/fcl/services/detectorclocks_icarus.fcl
@@ -24,7 +24,7 @@ BEGIN_PROLOG
 icarus_detectorclocks: {
     service_provider: "DetectorClocksServiceStandard"
 
-    TrigModuleName:    ""
+    TrigModuleName:    "daqTrigger"
     InheritClockConfig: true
     G4RefTime:        -1.5e3  # G4 time [us] where electronics clock counting start
     TriggerOffsetTPC: -0.340e3 # Time offset for TPC readout start time w.r.t. trigger [us]


### PR DESCRIPTION
The configuration of `DetectorClocksService` that ICARUS uses for both simulation and data was not configured to read the trigger information.
By now trigger information has been present in data (and optionally in simulation too) for more than 8 months, but we forgot to update the configuration of the service.
This commit registers the `daqTrigger` input tag as the trigger data product to be used. Because of the silent fallback to default values when no such data product is found, this change also "works" with simulation.

If a simulation job needs to include a global trigger, that trigger information should be encapsulated into a `std::vector<raw::Trigger>` data product named `daqTrigger`. `DetectorClocksService` supports only one (global) trigger; if multiple are needed for the same job, this service should not be used (but users can ask how to overcome that limitation).

In jobs like ICARUS "stage 0", where the service is initialized when the trigger information is not yet available, but by the end of the job such information may already be needed (maybe in optical reconstruction), this mechanism still works as long as the trigger module `daqTrigger` is run before it's needed: the service itself will read the trigger information on demand when `DataFor()` method is invoked.

Thanks to @ascarpel for reporting the suspicious behaviour in data (which was actually a bug). :star: 

Breaking change
==============

Although I am not sure whether any of our code correctly uses `DetectorClocksService` or cares that much of precise timing, any module relying on the service to learn the beam gate time can give different results than before this change.


Background
==========

`DetectorClocksService` and his family describe the proper time relations between components, including when the trigger happened, and when the beam gate was opened. The standard way to get the timing information is:
```cpp
detinfo::DetectorClocksData const detClocks
  = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
```
or equivalent.
In simulation, the "beam gate opening" is a fixed time (`1500` µs in this configuration) and the trigger time is learned from the `event` data (this holds also for samples with no implied beam). In data, the trigger time is at a fixed time (`1500` µs in this configuration) and the beam gate time is learned from the `event` data.
In both cases, `DetectorClocksServiceStandard` (that is our `DetectorClocksService` implementation of choice) looks in `event` for `raw::Trigger` collection data product with a input tag determined by the configuration. If such data product is not found, the timings are silently given a default value also in the configuration (`1500` µs in ours).
