### PR TITLE
Changing the default value of the electron lifetime to 3 ms

### DIFF
--- a/fcl/services/detectorproperties_icarus.fcl
+++ b/fcl/services/detectorproperties_icarus.fcl
@@ -7,7 +7,7 @@ icarus_detproperties: {
   
   ElectronsToADC:            1.208041e-3     # in ADC/e; 6241.5 electrons = 1fC
   Temperature:               87.5
-  Electronlifetime:          3500
+  Electronlifetime:          3000            # As agreed 3/17/22 to match measured value in East croystat
   # Active volume E-field calculated based on SBN-doc-23259 (H. Carranza and Z. Williams) using Vp = 75150 (from M. Mooney)
   Efield:                    [0.4938,0.733,0.933 ] #kV/cm to first,second,third wire planes
 


### PR DESCRIPTION
This was agreed in the ICARUS task force convener's meeting on 3/17/22 and is meant to match the measured value in the East cryostat. 