### PR TITLE
Overburden geometry picked as default

### DIFF
--- a/icarusalg/Geometry/geometry_icarus.fcl
+++ b/icarusalg/Geometry/geometry_icarus.fcl
@@ -68,6 +68,8 @@
 # 20200709 (petrillo@slac.stanford.edu)
 #   adopted split wire geometry fixed by
 #   Alessandro Menegolli (alessandro.menegolli@unipv.it)
+# 20220505 (petrillo@slac.stanford.edu)
+#   geometry default changed to include overburden
 #
 
 
@@ -303,7 +305,7 @@ icarus_nooverburden_geometry: @local::icarus_nooverburden_geometry_services.Geom
 ### Default ICARUS geometry configuration
 ### (`icarus_geometry_services`)
 ###
-### This configuration includes no overburden and long first induction wires
+### This configuration includes 3-m overburden and long first induction wires
 ### (18 m) as of now.
 ###
 ### Override a geometry configuration by:
@@ -318,7 +320,7 @@ icarus_nooverburden_geometry: @local::icarus_nooverburden_geometry_services.Geom
 #
 # geometry configuration bundle
 #
-icarus_geometry_services: @local::icarus_split_induction_nooverburden_geometry_services
+icarus_geometry_services: @local::icarus_split_induction_overburden_geometry_services
 
 #
 # Geometry service configuration:


### PR DESCRIPTION
This is a simple change that should turn the default geometry into the one with overburden.

Although it's something that ICARUS will sooner or later want to do, I am not aware of a decision been taken yet on when.

This is a GitHub commit — I count on the integration tests to spot syntax errors!
The commit is going to change the detected physics of cosmic rays, while it should not have an impact on neutrino and single particle events localised in the argon volume of the detector.

This pull request is intended for `develop` branch.