### PR TITLE
Utility to compute the allowed track time from its hits

### DIFF
--- a/icarusalg/Utilities/CMakeLists.txt
+++ b/icarusalg/Utilities/CMakeLists.txt
@@ -3,9 +3,13 @@ file(GLOB src_files *.cxx)
 cet_make_library(
   SOURCE ${src_files}
   LIBRARIES
+    lardataalg::DetectorInfo
+    lardataalg::headers
+    larcorealg::CoreUtils
+    lardataobj::RecoBase
+    canvas::canvas
     cetlib_except::cetlib_except
     CLHEP::CLHEP
-    larcorealg::CoreUtils
     Microsoft.GSL::GSL
   )
 

--- a/icarusalg/Utilities/PlotSandbox.tcc
+++ b/icarusalg/Utilities/PlotSandbox.tcc
@@ -530,7 +530,7 @@ Obj* icarus::ns::util::PlotSandbox<DirectoryBackend>::acquire(
   // object will be deleted, but its content will have been moved away already
   std::unique_ptr<Obj> local{ std::move(obj) };
   // problem: ROOT objects don't move that well
-  return make<Obj>(newName, newTitle, NoNameTitle, std::move(*obj));
+  return make<Obj>(newName, newTitle, NoNameTitle, std::move(*local));
 } // icarus::ns::util::PlotSandbox::acquire()
 
 

--- a/icarusalg/Utilities/PlotSandbox.tcc
+++ b/icarusalg/Utilities/PlotSandbox.tcc
@@ -527,7 +527,10 @@ Obj* icarus::ns::util::PlotSandbox<DirectoryBackend>::acquire(
 {
   std::string const& newName = name.empty()? obj->GetName(): name;
   std::string const& newTitle = title.empty()? obj->GetTitle(): title;
-  return make<Obj>(newName, newTitle, NoNameTitle, std::move(*(obj.release())));
+  // object will be deleted, but its content will have been moved away already
+  std::unique_ptr<Obj> local{ std::move(obj) };
+  // problem: ROOT objects don't move that well
+  return make<Obj>(newName, newTitle, NoNameTitle, std::move(*obj));
 } // icarus::ns::util::PlotSandbox::acquire()
 
 

--- a/icarusalg/Utilities/TrackTimeInterval.cxx
+++ b/icarusalg/Utilities/TrackTimeInterval.cxx
@@ -1,0 +1,318 @@
+/**
+ * @file icarusalg/Utilities/TrackTimeInterval.cxx
+ * @brief Utilities to constrain the time of charge detected in the TPC.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date May 18, 2023
+ * @see icarusalg/Utilities/TrackTimeInterval.h
+ */
+
+
+// library header
+#include "icarusalg/Utilities/TrackTimeInterval.h"
+
+// LArSoft libraries
+#include "larcorealg/CoreUtils/counter.h"
+#include "lardataobj/RecoBase/Hit.h"
+
+// C/C++ standard libraries
+#include <ostream>
+#include <utility> // std::move()
+#include <cmath> // std::abs()
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+lar::util::TrackTimeInterval::TrackTimeInterval(
+  geo::GeometryCore const& geom,
+  detinfo::DetectorPropertiesData detProp,
+  detinfo::DetectorTimings detTimings
+)
+  : TrackTimeInterval
+    { buildGeomCache(geom), std::move(detProp), std::move(detTimings) }
+  {}
+
+
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeInterval::timeRange(recob::Hit const& hit) const
+  -> TimeRange
+{
+  return timeRange(hit.PeakTime(), hit.WireID()); // that was easy...
+}
+
+
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeInterval::timeRange(
+  detinfo::timescales::TPCelectronics_tick_d TPCtick,
+  geo::PlaneID const& planeID /* = ... */
+) const -> TimeRange {
+  /*
+   * The time of arrival of some charge deposited at time t0 and at distance dX
+   * from an anode plane is:
+   *   t(P) = t0 + dt(D) = t0 + dX / v
+   * where dt(D) is the time it takes the charge to drift to the plane and v is
+   * the drift velocity, assumed uniform.
+   * That time of arrival is directly converted into a tick R(P) by the TPC
+   * readout electronics:
+   *   R(P) = R(ref) + (t(P) - t(ref)) / T
+   * where R(ref) is by construction the readout tick measured at the reference
+   * time t(ref), t(ref) is on the same time scale as t0 and T is the tick
+   * period (400 ns in ICARUS, 500 ns in MicroBooNE and others).
+   * R(P) is also the tick reconstructed by the hit reconstruction,
+   * `recob::Hit::PeakTime()`.
+   * 
+   * In this function we are interested in t0:
+   *
+   *     t(P) = t(ref) + T (R(P) - R(ref))
+   *     t0 = t(P) - dX / v = t(ref) + T (R(P) - R(ref)) - dX / v
+   *
+   * We don't know what dX is and the point of this function is to return the
+   * allowed interval of t0, which is covered by all the values of dX between
+   * `0` (on the anode plane) and `D` (distance of the cathode from the anode
+   * plane):
+   * 
+   *     t0(max) = t(ref) + T (R(P) - R(ref))
+   *     t0 in [ t0(max) - D / v ; t0(max) ]
+   *
+   * t(ref) is the time of the trigger, so if we express t0 relative to the
+   * trigger time we can omit it. The electronics time, on the other end,
+   * does not refer to the trigger time.
+   * `DetectorTimings` understands the time scale of R(P) (TPC electronics tick)
+   * and can convert it to other scales, e.g. the "standard" electronics scale,
+   * and give directly t0(max) in those other scales.
+   */
+  
+  detinfo::timescales::electronics_time const time
+    = fDetTimings.toElectronicsTime(TPCtick);
+  
+  TimeLimits_t const& planeTimeLimits = fGeomCache.limits[planeID];
+  microseconds const driftTime{
+    planeTimeLimits.driftDistance.convertInto<centimeters>().value()
+    / fDriftVelocity
+    };
+  return { time - driftTime, time };
+  
+} // lar::util::TrackTimeInterval::timeRange(tick)
+
+
+// -----------------------------------------------------------------------------
+lar::util::TrackTimeInterval::TrackTimeInterval(
+  GeometryCache_t geomCache,
+  detinfo::DetectorPropertiesData detProp,
+  detinfo::DetectorTimings detTimings
+)
+  : fDetProp{ std::move(detProp) }
+  , fDetTimings{ std::move(detTimings) }
+  , fDriftVelocity{ fDetProp.DriftVelocity() }
+  , fGeomCache{ std::move(geomCache) }
+  {}
+
+
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeInterval::buildGeomCache(geo::GeometryCore const& geom)
+  -> GeometryCache_t
+{
+  return {
+      extractTimeLimits(geom),                   // limits
+      { geom.Ncryostats(), geom.MaxTPCsets() },  // TPCsetDims
+      extractTPCtoSetMap(geom)                   // TPCtoSet
+    };
+} // lar::util::TrackTimeInterval::buildGeomCache()
+
+
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeInterval::extractTimeLimits
+  (geo::GeometryCore const& geom) -> GeometryCache_t::LimitsCache_t
+{
+  // this infrastructure and coding style is a remnant of a previous version
+  // which needed more information per plane and that information was different
+  // by plane; the following is still correct, has fewer assumptions and it's
+  // easier to expand, but a bit more wordy.
+  GeometryCache_t::LimitsCache_t limits = geom.makePlaneData<TimeLimits_t>();
+  
+  for (geo::TPCGeo const& TPC: geom.Iterate<geo::TPCGeo>()) {
+    geo::PlaneGeo const& firstPlane = TPC.FirstPlane();
+    
+    // in ICARUS the hit time is corrected as if it were on the first plane
+    // (the most inner one);
+    // TPC::DriftDistance() is based on the farthest plane,
+    // so we compute our own instead
+    geo::Point_t const& firstPlaneCenter = firstPlane.GetCenter();
+    geo::Point_t const& cathodeCenter = TPC.GetCathodeCenter();
+    
+    centimeters const driftDistance
+      { std::abs(TPC.DriftDir().Dot(cathodeCenter - firstPlaneCenter)) }; // cm
+    
+    for (geo::PlaneGeo const& plane: TPC.IteratePlanes()) {
+      
+      geo::PlaneID const& planeID = plane.ID();
+      
+      limits[planeID] = { driftDistance };
+      
+    } // for planes
+  } // for TPC
+  
+  return limits;
+} // lar::util::TrackTimeInterval::extractTimeLimits()
+
+
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeInterval::extractTPCtoSetMap
+  (geo::GeometryCore const& geom) -> GeometryCache_t::TPCtoSetMap_t
+{
+  GeometryCache_t::TPCtoSetMap_t map = geom.makeTPCData<readout::TPCsetID>();
+  
+  for (readout::TPCsetID const tpcsetID: geom.Iterate<readout::TPCsetID>()) {
+    assert(tpcsetID.isValid);
+    for (geo::TPCID tpcID: geom.TPCsetToTPCs(tpcsetID)) {
+      assert(tpcID.isValid);
+      map[tpcID] = tpcsetID;
+    }
+  } // for
+  
+  return map;
+} // lar::util::TrackTimeInterval::extractTPCtoSetMap()
+
+
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeInterval::mergeTPCsetRanges_SBN
+  (readout::TPCsetDataContainer<TimeRange> const& TPCsetRanges) const
+  -> TimeRange
+{
+  // reduce to each cryostat
+  std::vector<TimeRange> cryoRanges{ fGeomCache.Ncryostats() };
+  for (readout::CryostatID::CryostatID_t const cryoNo
+    : ::util::counter(cryoRanges.size())
+  ) {
+    readout::CryostatID const cryoID{ cryoNo };
+    
+    unsigned int const NTPCsets = fGeomCache.TPCsetDims[1];
+    
+    TimeRange& cryoRange = cryoRanges[cryoNo];
+    
+    // how do we combine time ranges from different TPCs?
+    // it depends on the layout; I am far from willing to write a generic
+    // algorithm for it, so here it goes the: SBN way!!
+    // This assumes that TPC sets 0 and 1 are around a cathode;
+    // and we don't support more than that.
+    
+    unsigned int const nCathodes = (NTPCsets + 1) / 2;
+    // the code below would work with more, but the choice is not well-motivated
+    assert(nCathodes == 1);
+    
+    for (unsigned int const TPCsetNo: ::util::counter(nCathodes)) {
+      
+      readout::TPCsetID const tpcsetID1(cryoID, TPCsetNo);
+      readout::TPCsetID const tpcsetID2(cryoID, TPCsetNo + 1);
+      cryoRange.intersect(mergeCathodeRanges(
+        TPCsetRanges.hasTPCset(tpcsetID1)? TPCsetRanges[tpcsetID1]: TimeRange{},
+        TPCsetRanges.hasTPCset(tpcsetID2)? TPCsetRanges[tpcsetID2]: TimeRange{}
+        ));
+      
+    } // for cathodes
+    
+  } // for cryostats
+  
+  // reduce to a single value
+  // if the time of the particle is one, then it must be the same in the
+  // different cryostats; so... yep, we once more intersect
+  
+  TimeRange mergedRange;
+  for (TimeRange const& range: cryoRanges) mergedRange.intersect(range);
+  
+  return mergedRange;
+} // lar::util::TrackTimeInterval::mergeTPCsetRanges_SBN()
+
+
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeInterval::mergeCathodeRanges
+  (TimeRange const& range1, TimeRange const& range2) const -> TimeRange
+{
+
+  if (!range2.isValid()) return range1; // even if range1 is itself invalid
+  if (!range1.isValid()) return range2;
+  
+  // there are two ranges at the two sides of the cathode;
+  // that pretty much means that the time for which the track hits touch the
+  // cathode is the right one (that is, the lowest value, "start");
+  // of course that cathode time may be not equal in the two drift volumes,
+  // because nothing ever goes as it should;
+  // so we give the range between the two times.
+  
+  electronics_time const time1 = range1.start;
+  electronics_time const time2 = range2.start;
+  return { std::min(time1, time2), std::max(time1, time2) };
+} // lar::util::TrackTimeInterval::mergeCathodeRanges()
+
+
+// -----------------------------------------------------------------------------
+geo::WireID lar::util::TrackTimeInterval::hitWire(recob::Hit const& hit)
+  { return hit.WireID(); }
+
+
+// -----------------------------------------------------------------------------
+// --- lar::util::TrackTimeInterval::TimeRange implementation
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeInterval::TimeRange::intersect(TimeRange const& other)
+  -> TimeRange&
+{
+  if ((start == UndefinedTime)
+    || ((other.start != UndefinedTime) && (other.start > start))
+  ) {
+    start = other.start;
+  }
+  
+  if ((stop == UndefinedTime)
+    || ((other.stop != UndefinedTime) && (other.stop < stop))
+  ) {
+    stop = other.stop;
+  }
+  
+  return *this;
+} // lar::util::TrackTimeInterval::TimeRange::intersect(TimeRange)
+
+
+// -----------------------------------------------------------------------------
+lar::util::TrackTimeInterval::TimeRange::operator std::string() const {
+  using namespace std::string_literals;
+  return isValid()
+    ? "[ "s
+      + ((start == UndefinedTime)? "..."s: to_string(start))
+      + " ; "
+      + ((stop == UndefinedTime)? "..."s: to_string(stop))
+      + " ]"
+    : "<invalid>"s
+    ;
+} // lar::util::operator<<(TrackTimeInterval::TimeRange)
+
+
+// -----------------------------------------------------------------------------
+std::ostream& lar::util::operator<<
+  (std::ostream& out, TrackTimeInterval::TimeRange const& range)
+{
+  // if this ever becomes a performance issue, the function may be reimplemented
+  // to directly pour into the stream
+  return out << std::string(range);
+} // lar::util::operator<<(TrackTimeInterval::TimeRange)
+
+
+// -----------------------------------------------------------------------------
+// ---  lar::util::TrackTimeIntervalMaker
+// -----------------------------------------------------------------------------
+lar::util::TrackTimeIntervalMaker::TrackTimeIntervalMaker
+  (geo::GeometryCore const& geom)
+  : fGeomCache{ TrackTimeInterval::buildGeomCache(geom) }
+  {}
+
+
+// -----------------------------------------------------------------------------
+auto lar::util::TrackTimeIntervalMaker::make(
+  detinfo::DetectorPropertiesData detProp,
+  detinfo::DetectorTimings detTimings
+) const -> TrackTimeInterval
+{
+  return
+    TrackTimeInterval{ fGeomCache, std::move(detProp), std::move(detTimings) };
+}
+
+
+// -----------------------------------------------------------------------------

--- a/icarusalg/Utilities/TrackTimeInterval.h
+++ b/icarusalg/Utilities/TrackTimeInterval.h
@@ -296,32 +296,32 @@ class lar::util::TrackTimeInterval {
   
   
   /**
+   * @brief Merges two ranges from the opposite sides of a cathode.
+   * @param range1 allowed time range from one side of the cathode
+   * @param range2 allowed time range from the other side of the cathode
+   * @return a single allowed time range
+   * 
+   * If both ranges are valid, the combination assumes that the actual time is
+   * locked and it is the time bringing both sides on the cathode (may result
+   * in a range of times).
+   * Otherwise, the range that is valid is returned as is.
+   */
+  TimeRange mergeCathodeRanges
+    (TimeRange const& range1, TimeRange const& range2) const;
+  
+  /**
    * @brief Merges the ranges from all the TPC sets in the detector.
    * @param TPCsetRanges container of allowed range from each TPC set
-   * @return a single allowed time range
+   * @return a combined range
    * 
    * As an input, each TPC set contributes its hypothesis of allowed time range;
    * that hypothesis is invalid (`!isValid()`) if there was no information in
    * the TPC set.
    * The combination assumes that all the hits belong to the same activity and
    * that the time of all that activity is only one.
-   * Contributions from different cryostats are intersected, while within each
-   * cryostat the combination is made in a detector-specific way (see
-   * `mergeTPCsetRanges_SBN()`.
-   */
-  TimeRange mergeCathodeRanges
-    (TimeRange const& range1, TimeRange const& range2) const;
-  
-  /**
-   * @brief Merges two ranges from the opposite sides of a cathode.
-   * @param range1 allowed time range from one side of the cathode
-   * @param range2 allowed time range from the other side of the cathode
-   * @return a combined range
-   * 
-   * If both ranges are valid, the combination assumes that the actual time is
-   * locked and it is the time bringing both sides on the cathode (may result
-   * in a range of times).
-   * Otherwise, the range that is valid is returned as is.
+   * Contributions from different cryostats are intersected, and within each
+   * cryostat the combination of the two TPC sets is also intersection of the
+   * two (see `mergeCathodeRanges()`).
    */
   TimeRange mergeTPCsetRanges_SBN
     (readout::TPCsetDataContainer<TimeRange> const& TPCsetRanges) const;

--- a/icarusalg/Utilities/TrackTimeInterval.h
+++ b/icarusalg/Utilities/TrackTimeInterval.h
@@ -1,0 +1,538 @@
+/**
+ * @file icarusalg/Utilities/TrackTimeInterval.h
+ * @brief Utilities to constrain the time of charge detected in the TPC.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date May 18, 2023
+ * @see icarusalg/Utilities/TrackTimeInterval.cxx
+ */
+
+#ifndef ICARUSALG_UTILITIES_TRACKTIMEINTERVAL_H
+#define ICARUSALG_UTILITIES_TRACKTIMEINTERVAL_H
+
+
+// LArSoft libraries
+#include "lardataalg/DetectorInfo/DetectorTimings.h"
+#include "lardataalg/DetectorInfo/DetectorTimingTypes.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
+#include "lardataalg/Utilities/quantities/spacetime.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcoreobj/SimpleTypesAndConstants/readout_types.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
+
+// framework libraries
+#include "canvas/Persistency/Common/Ptr.h"
+
+// C/C++ standard libraries
+#include <string>
+#include <iterator> // std::cbegin(), std::cend()
+#include <iosfwd>
+
+
+// -----------------------------------------------------------------------------
+namespace recob { class Hit; }
+
+// -----------------------------------------------------------------------------
+namespace lar::util {
+  using namespace ::util::quantities::time_literals;
+  class TrackTimeInterval;
+  class TrackTimeIntervalMaker;
+}
+/**
+ * @brief Returns the allowed time interval for TPC activity.
+ * 
+ * 
+ * Example of usage:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * geo::GeometryCore const& geom = *(lar::providerFrom<geo::Geometry const>());
+ * detinfo::DetectorTimings const detTimings
+ *   { art::ServiceHandle<detinfo::DetectorClocksService>()->DataFor(event) };
+ * detinfo::DetectorPropertiesData const& detProps{
+ *   art::ServiceHandle<detinfo::DetectorPropertiesService>()->DataFor
+ *     (event, detTimings.clockData())
+ *   };
+ * 
+ * lar::util::TrackTimeInterval const chargeTime{ geom, detProps, detTimings };
+ * 
+ * auto const& trackToHits
+ *   = event.getProduct<art::Assns<recob::Track, recob::Hit>>(trackTag);
+ * 
+ * for (auto const& [ trackPtr, hits ]
+ *   : util::associated_groups_with_left(trackToHits))
+ * {
+ *   
+ *   lar::util::TrackTimeInterval::TimeRange const hitTimeRange
+ *     = chargeTime.timeRangeOfHits(hits);
+ *   
+ *   recob::Track const& track = *trackPtr;
+ *   std::cout << "Track ID=" << track.ID() << " start=" << track.Start()
+ *     << " cm, end=" << track.end() << " cm, is confined in time interval "
+ *     << hitTimeRange << std::endl;
+ *   
+ * } // for
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * 
+ */
+class lar::util::TrackTimeInterval {
+  
+    public:
+  
+  using microseconds = ::util::quantities::intervals::microseconds;
+  using electronics_time = detinfo::timescales::electronics_time;
+  
+  
+  // ---  BEGIN  --- data structures -------------------------------------------
+  /// Record to describe a time interval.
+  struct TimeRange {
+    
+    /// Magic value for invalid times.
+    static constexpr electronics_time UndefinedTime
+      = std::numeric_limits<electronics_time>::lowest();
+    
+    /// Start of the interval (formally included).
+    electronics_time start = UndefinedTime;
+    
+    /// End of the interval (formally excluded).
+    electronics_time stop = UndefinedTime;
+    
+    /// Returns the extension of the range. It may be negative.
+    constexpr electronics_time::interval_t duration() const
+      { return stop - start; }
+    
+    /**
+     * @brief Returns if `time` is contained in the range, with some `margin`.
+     * @param time the time to be tested
+     * @param margin (default: no margin) extend the interval by this much time
+     * @return whether `time` is contained in the range within `margin`
+     * 
+     * If `margin` is negative, the interval is narrowed.
+     * The `stop` time is not included in the range.
+     * Inclusion in an invalid range is always `true`, because an invalid range
+     * (also) represents an infinite range.
+     */
+    constexpr bool contains
+      (electronics_time time, microseconds margin = 0_us) const
+      { return contains(time, margin, margin); }
+    
+    /**
+     * @brief Returns if `time` is contained in the range, with some margins.
+     * @param time the time to be tested
+     * @param startMargin the `start` is anticipated by this amount before check
+     * @param stopMargin the `stop` is delayed by this amount before check
+     * @return whether `time` is contained in the range within the margins
+     * 
+     * If a margin is negative, it narrows the range for the containment check.
+     * The `stop` time is not included in the range.
+     * Inclusion in an invalid range is always `true`, because an invalid range
+     * (also) represents an infinite range.
+     */
+    constexpr bool contains
+      (electronics_time time, microseconds startMargin, microseconds stopMargin)
+      const;
+    
+    /// Returns whether the interval is valid
+    /// (i.e. if at least one of the boundaries is defined).
+    constexpr bool isValid() const
+      { return (start != UndefinedTime) || (stop != UndefinedTime); }
+    
+    /// Returns whether the time range is empty.
+    constexpr bool empty() const { return start >= stop; }
+    
+    /// Returns a string representing this time range: `[ start ; stop ]`
+    /// or `<invalid>`.
+    operator std::string() const;
+    
+    /// Contracts this range to its intersection with the `other` one,
+    /// @return this object
+    TimeRange& intersect(TimeRange const& other);
+    
+  }; // TimeRange
+  
+  // ---  END  ----- data structures -------------------------------------------
+  
+  
+  /// Constructor: initializes with the specified detector properties.
+  TrackTimeInterval(
+    geo::GeometryCore const& geom,
+    detinfo::DetectorPropertiesData detProp,
+    detinfo::DetectorTimings detTimings
+    );
+  
+  
+  /**
+   * @brief Returns the allowed time range for charge detected on `TPCtick`.
+   * @param TPCtick tick at which the charge was detected in the TPC readout
+   * @return an exact time range for the activity
+   * 
+   * 
+   */
+  TimeRange timeRange(double TPCtick, geo::PlaneID const& planeID) const;
+  
+  
+  TimeRange timeRange(
+    detinfo::timescales::TPCelectronics_tick_d tick,
+    geo::PlaneID const& planeID
+  ) const;
+  
+  /// Returns the time range for the hit
+  /// (`recob::Hit::PeakTime()` is used as time).
+  /// @see `timeRange(double) const`
+  TimeRange timeRange(recob::Hit const& hit) const;
+  
+  
+  /// Unfolds C pointers (returns an invalid range if `ptr` is null).
+  template <typename T>
+  TimeRange timeRange(T const* ptr) const
+    { return ptr? timeRange(*ptr): TimeRange{}; }
+  
+  /// Unfolds _art_ pointers (returns an invalid range if `ptr` is null).
+  template <typename T>
+  TimeRange timeRange(art::Ptr<T> const& ptr) const
+    { return timeRange(ptr.get()); }
+  
+  
+  
+  /**
+   * @brief Returns the time range including all the times in a sequence.
+   * @tparam BIter type of begin iterator
+   * @tparam EIter type of end iterator
+   * @param begin iterator to the sequence
+   * @param end iterator past the end of the sequence
+   * @return time range including all `recob::Hit` in the collection
+   * 
+   * All objects in the sequence must be acceptable arguments for a
+   * `timeRange()` call.
+   * 
+   * For the hits in each drift volume (TPC set), the allowed time range is an
+   * intersection of allowed time ranges from all the hits in that volume.
+   * That range can be empty and also have "negative duration", `start`ing after
+   * having `stop`ped: this means that the lowest stop is earlier than the
+   * higher start.
+   * 
+   * If the hits span multiple drift volumes, they are combined using the
+   * detector-dependent method `mergeTPCsetRanges_SBN()`.
+   * 
+   * If no element is present in the sequence, the time range is returned
+   * invalid (`TimeRange::isValid()` returns `false`).
+   */
+  template <typename BIter, typename EIter>
+  TimeRange timeRangeOfHits(BIter begin, EIter end) const;
+  
+  /**
+   * @brief Returns the time range including all `recob::Hit` in the collection.
+   * @tparam HitColl type of hit collection
+   * @param hitColl the collection of hits
+   * @return time range including all `recob::Hit` in the collection
+   * @see `timeRange(BIter, EIter) const`
+   * 
+   * See `timeRange(BIter begin, EIter end) const` for details.
+   * 
+   * Type requirements
+   * ------------------
+   * 
+   * `HitColl` must be a forward-iterable sequence whose elements are each one
+   * compatible with a `timeRange()` call.
+   * 
+   */
+  template <typename HitColl>
+  TimeRange timeRangeOfHits(HitColl const& hits) const;
+  
+  
+    private:
+  friend class TrackTimeIntervalMaker;
+  
+  using centimeters = ::util::quantities::intervals::centimeters;
+  struct TimeLimits_t {
+    centimeters driftDistance;
+  };
+  
+  struct GeometryCache_t {
+    using LimitsCache_t = geo::PlaneDataContainer<TimeLimits_t>;
+    using TPCtoSetMap_t = geo::TPCDataContainer<readout::TPCsetID>;
+    
+    /// Cached times for all the planes in the detector.
+    LimitsCache_t limits;
+    
+    /// Cached dimensions for a TPC set data container.
+    std::array<unsigned int, 2U> TPCsetDims;
+    
+    /// TPC to TPC set map.
+    TPCtoSetMap_t TPCtoSet;
+    
+    /// Returns the cached number of cryostats in the detector.
+    unsigned int Ncryostats() const { return TPCsetDims[0]; }
+    
+  }; // GeometryCache_t
+  
+  
+  /// Constructor: uses a provided cache instead of creating it.
+  TrackTimeInterval(
+    GeometryCache_t geomCache,
+    detinfo::DetectorPropertiesData detProp,
+    detinfo::DetectorTimings detTimings
+    );
+  
+  
+  /// Local copy of detector properties.
+  detinfo::DetectorPropertiesData const fDetProp;
+  
+  /// Local copy of the timing conversion utility (including `DetectorClocks`).
+  detinfo::DetectorTimings const fDetTimings;
+  
+  double const fDriftVelocity; ///< Detector drift velocity [cm/us]
+  
+  GeometryCache_t const fGeomCache; ///< Cached geometry information.
+  
+  
+  /// Creates a geometry cache.
+  static GeometryCache_t buildGeomCache(geo::GeometryCore const& geom);
+  
+  /// Returns the time limits of all the planes in the specified TPC.
+  static GeometryCache_t::LimitsCache_t extractTimeLimits
+    (geo::GeometryCore const& geom);
+  
+  static GeometryCache_t::TPCtoSetMap_t extractTPCtoSetMap
+    (geo::GeometryCore const& geom);
+  
+  
+  /**
+   * @brief Merges the ranges from all the TPC sets in the detector.
+   * @param TPCsetRanges container of allowed range from each TPC set
+   * @return a single allowed time range
+   * 
+   * As an input, each TPC set contributes its hypothesis of allowed time range;
+   * that hypothesis is invalid (`!isValid()`) if there was no information in
+   * the TPC set.
+   * The combination assumes that all the hits belong to the same activity and
+   * that the time of all that activity is only one.
+   * Contributions from different cryostats are intersected, while within each
+   * cryostat the combination is made in a detector-specific way (see
+   * `mergeTPCsetRanges_SBN()`.
+   */
+  TimeRange mergeCathodeRanges
+    (TimeRange const& range1, TimeRange const& range2) const;
+  
+  /**
+   * @brief Merges two ranges from the opposite sides of a cathode.
+   * @param range1 allowed time range from one side of the cathode
+   * @param range2 allowed time range from the other side of the cathode
+   * @return a combined range
+   * 
+   * If both ranges are valid, the combination assumes that the actual time is
+   * locked and it is the time bringing both sides on the cathode (may result
+   * in a range of times).
+   * Otherwise, the range that is valid is returned as is.
+   */
+  TimeRange mergeTPCsetRanges_SBN
+    (readout::TPCsetDataContainer<TimeRange> const& TPCsetRanges) const;
+  
+  
+  /// Returns a copy of the wire ID of a `hit`.
+  static geo::WireID hitWire(recob::Hit const& hit);
+  
+  /// Returns a copy of the wire ID of a `hit`.
+  static geo::WireID hitWire(recob::Hit const* hit) { return hitWire(*hit); }
+  
+  /// Returns a copy of the wire ID of a hit.
+  static geo::WireID hitWire(art::Ptr<recob::Hit> const& hitPtr)
+     { return hitWire(*hitPtr); }
+  
+  /// Returns a `readout::TPCsetDataContainer` with the cached dimensions.
+  template <typename T>
+  readout::TPCsetDataContainer<T> makeTPCsetData() const;
+  
+  
+}; // lar::util::TrackTimeInterval
+
+
+namespace lar::util {
+  /// Prints a time range to a text stream.
+  std::ostream& operator<<
+    (std::ostream& out, lar::util::TrackTimeInterval::TimeRange const& range);
+}
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Creates instances of `lar::util::TrackTimeInterval`.
+ * 
+ * `lar::util::TrackTimeInterval` classes require in principle per-event
+ * information and they should be created on each new event.
+ * They are designed to work with many hits at once, so they cache some
+ * information to reduce the computing time, and part of that information is
+ * not event-dependent.
+ * 
+ * To avoid the recalculation of that part of information, this class computes
+ * it once at construction, and then it copies that to a new `TrackTimeInterval`
+ * object any time one is requested.
+ * This object should be declared as a data member of an analysis class
+ * (an _art_ module, for example), and in the event loop it should be invoked
+ * to get a usable `lar::util::TrackTimeInterval`.
+ * 
+ * Example of usage:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * class MyAnalysis: art::SharedAnalyzer {
+ *   
+ *   geo::GeometryCore const& fGeom;
+ *   detinfo::DetectorClocksService const& fDetClocks;
+ *   detinfo::DetectorPropertiesService const& fDetProp;
+ *   
+ *   lar::util::TrackTimeIntervalMaker const fTimeIntervalMaker;
+ *   
+ *   // ...
+ *   
+ *   MyAnalysis()
+ *     : fGeom(*lar::providerFrom<geo::GeometryCore>())
+ *     , fDetClocks(*art::ServiceHandle<detinfo::DetectorClocksService>())
+ *     , fDetProp(*art::ServiceHandle<detinfo::DetectorPropertiesService>())
+ *     , fTimeIntervalMaker{ fGeom }
+ *     // ...
+ *     {}
+ *   
+ *   void analyze(art::Event const& event) override;
+ *   
+ * };
+ * 
+ * 
+ * void MyAnalysis::analyze(Event const& event) {
+ *   
+ *   detinfo::DetectorTimings const detTimings{ fDetClocks.DataFor(event) };
+ *   detinfo::DetectorPropertiesData const& detProp
+ *     { fDetProp.DataFor(event, detTimings.clockData()) };
+ *   
+ *   lar::util::TrackTimeInterval const timeIntervals
+ *     = fTimeIntervalMaker(detProp, detTimings);
+ *   
+ *   // ... use timeIntervals
+ *   
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * This is as opposed to _not_ using the maker:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * class MyAnalysis: art::SharedAnalyzer {
+ *   
+ *   geo::GeometryCore const& fGeom;
+ *   detinfo::DetectorClocksService const& fDetClocks;
+ *   detinfo::DetectorPropertiesService const& fDetProp;
+ *   
+ *   // ...
+ *   
+ *   MyAnalysis()
+ *     : fGeom(*lar::providerFrom<geo::GeometryCore>())
+ *     , fDetClocks(*art::ServiceHandle<detinfo::DetectorClocksService>())
+ *     , fDetProp(*art::ServiceHandle<detinfo::DetectorPropertiesService>())
+ *     // ...
+ *     {}
+ *   
+ *   void analyze(art::Event const& event) override;
+ *   
+ * };
+ * 
+ * 
+ * void MyAnalysis::analyze(Event const& event) {
+ *   
+ *   detinfo::DetectorTimings const detTimings{ fDetClocks.DataFor(event) };
+ *   detinfo::DetectorPropertiesData const& detProp
+ *     { fDetProp.DataFor(event, detTimings.clockData()) };
+ *   
+ *   lar::util::TrackTimeInterval const timeIntervals
+ *     { geom, detProp, detTimings };
+ *   
+ *   // ... use timeIntervals
+ *   
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * which does not benefit from the precomputed cache.
+ */
+class lar::util::TrackTimeIntervalMaker {
+  
+  /// Geometry cache to be copied to the `TrackTimeInterval` objects.
+  TrackTimeInterval::GeometryCache_t const fGeomCache;
+  
+    public:
+  
+  /// Constructor: creates a cache from the geometry.
+  TrackTimeIntervalMaker(geo::GeometryCore const& geom);
+  
+  //@{
+  /// Returns a new `TrackTimeInterval` with the specified detector properties.
+  TrackTimeInterval make(
+    detinfo::DetectorPropertiesData detProp,
+    detinfo::DetectorTimings detTimings
+    ) const;
+  
+  TrackTimeInterval operator() (
+    detinfo::DetectorPropertiesData detProp,
+    detinfo::DetectorTimings detTimings
+    ) const
+    { return make(std::move(detProp), std::move(detTimings)); }
+  //@}
+  
+}; // lar::util::TrackTimeIntervalMaker
+
+
+
+// -----------------------------------------------------------------------------
+// ---  Inline implementation
+// -----------------------------------------------------------------------------
+inline constexpr bool lar::util::TrackTimeInterval::TimeRange::contains
+  (electronics_time time, microseconds startMargin, microseconds stopMargin)
+  const
+{
+  return ((start == UndefinedTime) || (time >= start - startMargin))
+    && ((stop == UndefinedTime) || (time < stop + stopMargin));
+}
+
+
+// -----------------------------------------------------------------------------
+inline auto lar::util::TrackTimeInterval::timeRange
+  (double TPCtick, geo::PlaneID const& planeID) const -> TimeRange
+{
+  return
+    timeRange(detinfo::timescales::TPCelectronics_tick_d{ TPCtick }, planeID);
+}
+
+
+// -----------------------------------------------------------------------------
+// ---  Template implementation
+// -----------------------------------------------------------------------------
+template <typename BIter, typename EIter>
+auto lar::util::TrackTimeInterval::timeRangeOfHits(BIter begin, EIter end) const
+  -> TimeRange
+{
+  auto TPCsetRanges = makeTPCsetData<TimeRange>();
+  
+  // per TPC set (i.e. drift volume)
+  while (begin != end) {
+    readout::TPCsetID const tpcsetID = fGeomCache.TPCtoSet.at(hitWire(*begin));
+    TPCsetRanges[tpcsetID].intersect(timeRange(*begin++));
+  }
+  
+  return mergeTPCsetRanges_SBN(TPCsetRanges);
+} // lar::util::TrackTimeInterval::timeRangeOfHits(Iter)
+
+
+// -----------------------------------------------------------------------------
+template <typename HitColl>
+auto lar::util::TrackTimeInterval::timeRangeOfHits(HitColl const& hits) const
+  -> TimeRange
+{
+  using std::cbegin, std::cend;
+  return timeRangeOfHits(cbegin(hits), cend(hits));
+} // lar::util::TrackTimeInterval::timeRangeOfHits(HitColl)
+
+
+// -----------------------------------------------------------------------------
+template <typename T>
+readout::TPCsetDataContainer<T> lar::util::TrackTimeInterval::makeTPCsetData
+  () const
+{
+  return readout::TPCsetDataContainer<T>
+    { fGeomCache.TPCsetDims[0], fGeomCache.TPCsetDims[1] };
+} // lar::util::TrackTimeInterval::makeTPCsetData()
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSALG_UTILITIES_TRACKTIMEINTERVAL_H

--- a/icarusalg/Utilities/TrackTimeInterval.h
+++ b/icarusalg/Utilities/TrackTimeInterval.h
@@ -40,8 +40,29 @@ namespace lar::util {
 /**
  * @brief Returns the allowed time interval for TPC activity.
  * 
+ * This simple utility returns a range of times
+ * (@ref DetectorClocksElectronicsTime "electronics time scale")
+ * the track may have been detected at, given the time of its associated hits.
  * 
- * Example of usage:
+ * The keyword is "simple": the algorithm just compares hit times to the nominal
+ * drift velocity and detector coordinates, and draws its conclusions from
+ * there. That means that it does not take advantage of a precise location of
+ * the cathode (LArSoft geometry does not provide one), nor of the anode (the
+ * first charge readout plane is used as reference), not of deformations in the
+ * actual geometry of the detector nor in the drift field and velocity.
+ * **The advise is to allow a forgiving margin when using the range returned by
+ * this utility** (the `contains()` method of the class used to report the
+ * result, `TimeRange`, pointedly and deliberately includes arguments for
+ * margins).
+ * 
+ * Despite the "track` in the name, the interface allows to specify a collection
+ * of hits, or hit times, but not a `recob::Track` (associated hits needs to be
+ * discovered before the call).
+ * 
+ * 
+ * Example of usage
+ * -----------------
+ * 
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
  * geo::GeometryCore const& geom = *(lar::providerFrom<geo::Geometry const>());
  * detinfo::DetectorTimings const detTimings

--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -32,3 +32,15 @@ cet_test(NonRandomCounter_test
     cetlib::cetlib
   USE_BOOST_UNIT
   )
+
+cet_test(TrackTimeInterval_test USE_BOOST_UNIT
+  TEST_ARGS -- standard_g4_icarus.fcl
+  LIBRARIES PRIVATE
+  icarusalg::Utilities
+  icarusalg::Geometry
+  lardataalg::DetectorInfo_TestHelpers
+  lardataalg::DetectorInfo
+  larcorealg::geometry_unit_test_base
+  larcorealg::Geometry
+  lardataobj::RecoBase
+)

--- a/test/Utilities/TrackTimeInterval_test.cc
+++ b/test/Utilities/TrackTimeInterval_test.cc
@@ -1,0 +1,429 @@
+/**
+ * @file   TrackTimeInterval_test.cc
+ * @brief  Unit test for `lar::util::TrackTimeInterval` with ICARUS geometry.
+ * @date   May 19th, 2023
+ * @author petrillo@slac.stanford.edu
+ *
+ * Usage: just run the executable.
+ * Or plug a FHiCL file in the command line.
+ * 
+ * There is only one ICARUS-specific line in this code, that is the choice
+ * of channel mapping. In fact, the test would probably work for ICARUS
+ * even with the default channel mapping.
+ */
+
+// Boost test libraries; defining this symbol tells boost somehow to generate
+// a main() function; Boost is pulled in by boost_unit_test_base.h
+#define BOOST_TEST_MODULE TrackTimeIntervalTest
+
+// ICARUS libraries
+#include "icarusalg/Utilities/TrackTimeInterval.h"
+#include "icarusalg/Geometry/ICARUSChannelMapAlg.h"
+
+// LArSoft libraries
+#include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
+#include "lardataalg/DetectorInfo/LArPropertiesStandard.h"
+#include "lardataalg/DetectorInfo/DetectorClocksStandard.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesStandardTestHelpers.h"
+#include "lardataalg/DetectorInfo/DetectorClocksStandardTestHelpers.h"
+#include "lardataalg/DetectorInfo/LArPropertiesStandardTestHelpers.h"
+#include "lardataalg/Utilities/quantities/spacetime.h" // microseconds
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/Geometry/TPCGeo.h"
+#include "larcorealg/Geometry/PlaneGeo.h"
+#include "larcorealg/CoreUtils/counter.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
+#include "larcorealg/TestUtils/boost_unit_test_base.h"
+#include "larcorealg/TestUtils/geometry_unit_test_base.h"
+#include "lardataobj/RecoBase/Hit.h"
+
+// standard C/C++ libraries
+#include <stdexcept> // std::runtime_error
+#include <iostream>
+#include <random>
+#include <vector>
+#include <string>
+#include <optional>
+#include <cmath> // std::abs()
+#include <cassert>
+
+
+//------------------------------------------------------------------------------
+//---  The test environment
+//---
+
+using TesterConfiguration =
+  testing::BasicGeometryEnvironmentConfiguration<icarus::ICARUSChannelMapAlg>;
+using TestEnvironment = testing::GeometryTesterEnvironment<TesterConfiguration>;
+
+
+class TestFixture {
+
+  // the initialization of the static object needs to be delayed
+  // until the inizialization of an instance of the fixture happens.
+  static std::optional<TestEnvironment> gEnv;
+  
+  static void initGlobalTestEnv()
+    {
+      int const argc = boost::unit_test::framework::master_test_suite().argc;
+      auto const argv = boost::unit_test::framework::master_test_suite().argv;
+      
+      if (argc != 2)
+        throw std::runtime_error("FHiCL configuration file path required as first argument!");
+      
+      TesterConfiguration config{ "TrackTimeIntervalTest" };
+      int iParam = 0;
+      config.SetConfigurationPath(argv[++iParam]);
+      
+      gEnv.emplace(config);
+      TestEnvironment& testEnv = *gEnv;
+      // DetectorPropertiesStandard and all its dependencies support the simple set
+      // up (see testing::TesterEnvironment::SimpleProviderSetup()), except for
+      // Geometry, that has been configured already in the geometry-aware
+      // environment. So we invoke a simple set up for each of the dependencies:
+      testEnv.SimpleProviderSetup<detinfo::LArPropertiesStandard>();
+      testEnv.SimpleProviderSetup<detinfo::DetectorClocksStandard>();
+      testEnv.SimpleProviderSetup<detinfo::DetectorPropertiesStandard>();
+    }
+  
+    public:
+  
+  /// Setup: may initialize the global environment.
+  TestFixture() { if (!gEnv) initGlobalTestEnv(); }
+
+  /// Retrieves the global tester
+  static TestEnvironment const& Env() { return gEnv.value(); }
+
+}; // class TestFixture
+
+std::optional<TestEnvironment> TestFixture::gEnv;
+
+
+//------------------------------------------------------------------------------
+namespace {
+  
+  recob::Hit makeHitAt(
+    raw::ChannelID_t channel, float tick,
+    geo::View_t view, geo::SigType_t signalType, geo::WireID const& wireID
+  ) {
+    return {
+        channel            // channel
+      , int(tick) - 20     // start_tick
+      , int(tick) + 20     // end_tick
+      , tick               // peak_time
+      , 3.0                // sigma_peak_time
+      , 4.0                // rms
+      , 100.0              // peak_amplitude
+      , 5.0                // sigma_peak_amplitude
+      , 200                // summedADC
+      , 200.0              // hit_integral
+      , 10.0               // hit_sigma_integral
+      , 1                  // multiplicity
+      , 0                  // local_index
+      , 1.0                // goodness_of_fit
+      , 37                 // dof
+      , view               // view
+      , signalType         // signal_type
+      , wireID             // wireID
+      };
+  } // makeHitAt()
+  
+} // local namespace
+
+//------------------------------------------------------------------------------
+//---  The tests
+//---
+//
+// Note on Boost fixture options:
+// - BOOST_FIXTURE_TEST_SUITE will provide the tester as a always-present data
+//   member in the environment, as "Tester()"; but a new fixture, with a new
+//   geometry and a new tester, is initialized on each test case
+// - BOOST_GLOBAL_FIXTURE does not provide tester access, so one has to get it
+//   as TestFixture::GlobalTester(); on the other hand, the
+//   fixture is initialized only when a new global one is explicitly created.
+//
+
+// BOOST_FIXTURE_TEST_SUITE(TrackTimeIntervalTestEnv, TestFixture)
+BOOST_GLOBAL_FIXTURE(TestFixture);
+
+BOOST_AUTO_TEST_CASE(PrintHitsOnAllPlanes)
+{
+  auto const& testEnv = TestFixture::Env();
+  auto const detClockData
+    = testEnv.Provider<detinfo::DetectorClocks>()->DataForJob();
+  
+  geo::GeometryCore const& geom = *(testEnv.Provider<geo::GeometryCore>());
+  detinfo::DetectorPropertiesData detProp
+    = testEnv.Provider<detinfo::DetectorProperties>()->DataFor(detClockData);
+  
+  const int MaxTick = detProp.ReadOutWindowSize();
+  
+  lar::util::TrackTimeInterval const chargeTime
+    { geom, detProp, detinfo::DetectorTimings{ detClockData } };
+  
+  for (geo::PlaneGeo const& plane: geom.Iterate<geo::PlaneGeo>()) {
+    
+    //
+    // make some hits on this plane
+    //
+    std::vector<recob::Hit> hits;
+    
+    geo::WireID const wireID{ plane.ID(), 1 };
+    raw::ChannelID_t const channel = geom.PlaneWireToChannel(wireID);
+    geo::SigType_t const signalType = geom.SignalType(channel);
+    geo::View_t const view = plane.View();
+    
+    int tick = 0;
+    int tickStep = MaxTick / 16;
+    while (tick <= MaxTick) {
+      hits.push_back(makeHitAt(channel, tick, view, signalType, wireID));
+      tick += tickStep;
+    } // while
+    
+    //
+    // print all the time ranges
+    //
+    std::cout << std::string("=", 80) << "\n" << plane.ID() << std::endl;
+    for (recob::Hit const& hit: hits) {
+      
+      lar::util::TrackTimeInterval::TimeRange const& hitTimeRange
+        = chargeTime.timeRange(hit);
+      
+      std::cout << hit.WireID() << " T=" << hit.PeakTime() << " => "
+        << hitTimeRange << std::endl;
+      
+    } // for hits
+    
+  } // for planes
+  
+} // BOOST_AUTO_TEST_CASE(PrintHitsOnAllPlanes)
+
+
+BOOST_AUTO_TEST_CASE(HitsOnPlanes)
+{
+  using electronics_time = detinfo::timescales::electronics_time;
+  
+  auto const& testEnv = TestFixture::Env();
+  auto const detClockData
+    = testEnv.Provider<detinfo::DetectorClocks>()->DataForJob();
+  detinfo::DetectorTimings const detTiming{ detClockData };
+  
+  geo::GeometryCore const& geom = *(testEnv.Provider<geo::GeometryCore>());
+  detinfo::DetectorPropertiesData detProp
+    = testEnv.Provider<detinfo::DetectorProperties>()->DataFor(detClockData);
+  
+  lar::util::TrackTimeInterval const chargeTime{ geom, detProp, detTiming };
+  
+  electronics_time const triggerTime [[maybe_unused]] = detTiming.TriggerTime();
+  
+  double const driftVelocity = detProp.DriftVelocity();
+  
+  for (geo::TPCGeo const& TPC: geom.Iterate<geo::TPCGeo>()) {
+    
+    // refer to the first plane (ICARUS does that)
+    geo::Point_t const firstPlaneCenter = TPC.FirstPlane().GetCenter();
+    geo::Point_t const cathodeCenter = TPC.GetCathodeCenter();
+    double const driftDistance
+      = std::abs(cathodeCenter.X() - firstPlaneCenter.X());
+    util::quantities::microseconds const driftTime
+      { driftDistance / driftVelocity };
+    
+    for (geo::PlaneGeo const& plane: TPC.IteratePlanes()) {
+      geo::WireID const wireID{ plane.ID(), 1 };
+      raw::ChannelID_t const channel = geom.PlaneWireToChannel(wireID);
+      geo::SigType_t const signalType = geom.SignalType(channel);
+      geo::View_t const view = plane.View();
+      
+      // a hit at the anode at trigger time arrives immediately at trigger time;
+      // that time can be also charge deposited at the cathode one drift time
+      // earlier than the trigger time
+      recob::Hit const anodeHit = makeHitAt(
+        channel, detProp.ConvertXToTicks(firstPlaneCenter.X(), wireID),
+        view, signalType, wireID
+        );
+      lar::util::TrackTimeInterval::TimeRange const anodeHitTimeRange
+        = chargeTime.timeRange(anodeHit);
+
+      BOOST_TEST(anodeHitTimeRange.start.value() == (triggerTime - driftTime).value(),
+                 boost::test_tools::tolerance(0.001));
+      BOOST_TEST(anodeHitTimeRange.stop.value() == triggerTime.value(),
+                 boost::test_tools::tolerance(0.001));
+
+      // a hit at the cathode at trigger time arrives one drift time later;
+      // that time can be also charge deposited at the anode one drift time
+      // after the trigger time
+      recob::Hit const cathodeHit = makeHitAt(
+        channel, detProp.ConvertXToTicks(cathodeCenter.X(), wireID),
+        view, signalType, wireID
+        );
+      lar::util::TrackTimeInterval::TimeRange const cathodeHitTimeRange
+        = chargeTime.timeRange(cathodeHit);
+
+      BOOST_TEST(cathodeHitTimeRange.start.value() == triggerTime.value(),
+                 boost::test_tools::tolerance(0.001));
+      BOOST_TEST(cathodeHitTimeRange.stop.value() == (triggerTime + driftTime).value(),
+                 boost::test_tools::tolerance(0.001));
+      
+    } // for planes
+  } // for TPC
+  
+  
+} // BOOST_AUTO_TEST_CASE(HitsOnPlanes)
+
+
+BOOST_AUTO_TEST_CASE(PrintHitTimes)
+{
+  /*
+   * Not much of a test: it mostly prints the allowed ranges for hits
+   * reconstructed at different drift distances.
+   * A single TPC is used as reference.
+   * 
+   */
+  auto const& testEnv = TestFixture::Env();
+  auto const detClockData
+    = testEnv.Provider<detinfo::DetectorClocks>()->DataForJob();
+  detinfo::DetectorTimings const detTiming{ detClockData };
+  
+  geo::GeometryCore const& geom = *(testEnv.Provider<geo::GeometryCore>());
+  detinfo::DetectorPropertiesData detProp
+    = testEnv.Provider<detinfo::DetectorProperties>()->DataFor(detClockData);
+  
+  lar::util::TrackTimeInterval const chargeTime{ geom, detProp, detTiming };
+  
+  double const driftVelocity = detProp.DriftVelocity(); // cm/us
+  
+  geo::TPCGeo const& TPC = geom.TPC(geo::TPCID{ 0, 0 });
+    
+  BOOST_TEST_MESSAGE("Hit times for " << TPC.ID());
+  
+  double const driftLength = std::abs(
+    TPC.DriftDir().Dot(TPC.GetCathodeCenter() - TPC.FirstPlane().GetCenter())
+    );
+  
+  geo::PlaneGeo const& plane = TPC.FirstPlane();
+  geo::WireID::WireID_t const refWireNo = 100;
+  
+  double const xC = TPC.GetCathodeCenter().X();
+  double const xA = plane.GetCenter().X();
+  auto const xCoord = [x0=xA,L=xC-xA](double u){ return x0 + L * u; };
+  
+  raw::ChannelID_t const refChannel
+    = geom.PlaneWireToChannel({ plane.ID(), 100 });
+  geo::SigType_t const signalType = geom.SignalType(refChannel);
+  geo::View_t const view = plane.View();
+  
+  std::default_random_engine engine; // default seed, not that random
+  
+  for (auto const i: util::counter(31)) {
+    double const x = -1.0 + 0.1 * i;
+    
+    double const timeSpan = driftLength / driftVelocity; // us
+    
+    recob::Hit const hit = makeHitAt(
+      refChannel + i, detProp.ConvertXToTicks(xCoord(x), plane.ID()),
+        view, signalType, { plane.ID(), refWireNo + i }
+        );
+    
+    lar::util::TrackTimeInterval::TimeRange const& timeRange
+      = chargeTime.timeRange(hit);
+    
+    std::cout << "Hit at " << x << " of drift: time range: " << timeRange
+      << std::endl;
+    
+    BOOST_TEST(timeRange.duration().value() == timeSpan,
+               boost::test_tools::tolerance(0.001));
+    
+  } // for hit
+  
+} // BOOST_AUTO_TEST_CASE(PrintHitTimes)
+
+
+
+BOOST_AUTO_TEST_CASE(timeRangeOfHits_singleTPCset)
+{
+  auto const& testEnv = TestFixture::Env();
+  auto const detClockData
+    = testEnv.Provider<detinfo::DetectorClocks>()->DataForJob();
+  detinfo::DetectorTimings const detTiming{ detClockData };
+  
+  geo::GeometryCore const& geom = *(testEnv.Provider<geo::GeometryCore>());
+  detinfo::DetectorPropertiesData detProp
+    = testEnv.Provider<detinfo::DetectorProperties>()->DataFor(detClockData);
+  
+  // let's try the maker this time...
+  lar::util::TrackTimeIntervalMaker const trackTimeIntervalMaker{ geom };
+  lar::util::TrackTimeInterval const chargeTime
+    = trackTimeIntervalMaker(detProp, detTiming);
+  
+  double const driftVelocity = detProp.DriftVelocity(); // cm/us
+  
+  for (geo::TPCGeo const& TPC: geom.Iterate<geo::TPCGeo>()) {
+    
+    BOOST_TEST_MESSAGE("Track test for " << TPC.ID());
+    
+    double const driftLength = std::abs(
+      TPC.DriftDir().Dot(TPC.GetCathodeCenter() - TPC.FirstPlane().GetCenter())
+      );
+    
+    geo::PlaneGeo const& plane = TPC.FirstPlane();
+    geo::WireID::WireID_t const refWireNo = 100;
+    
+    double const xC = TPC.GetCathodeCenter().X();
+    double const xA = plane.GetCenter().X();
+    auto const xCoord = [x0=xA,L=xC-xA](double u){ return x0 + L * u; };
+    
+    raw::ChannelID_t const refChannel
+      = geom.PlaneWireToChannel({ plane.ID(), 100 });
+    geo::SigType_t const signalType = geom.SignalType(refChannel);
+    geo::View_t const view = plane.View();
+    
+    std::default_random_engine engine; // default seed, not that random
+    
+    for (auto const [ Xa, Xb ]: {
+        std::make_pair(0.2, 0.6)
+      , std::make_pair(0.5, 0.8)
+      , std::make_pair(-0.2, 0.1)
+      , std::make_pair(0.0, 1.0)
+      , std::make_pair(-0.2, 0.8)
+      , std::make_pair(0.2, 1.2)
+      , std::make_pair(-0.2, 1.2)
+    }) {
+      
+      double const timeSpan
+        = driftLength * (1.0 - std::abs(Xb - Xa)) / driftVelocity; // us
+      
+      constexpr std::size_t N = 5;
+      std::array<recob::Hit, N> trackHits;
+      double const step = (Xb - Xa)/(N-1);
+      
+      for (std::size_t i = 0; i < N; ++i) {
+        double const x = Xa + i * step;
+        trackHits[i] = makeHitAt(
+          refChannel + i, detProp.ConvertXToTicks(xCoord(x), plane.ID()),
+            view, signalType, { plane.ID(), refWireNo + i }
+            );
+      } // for hit positions
+      
+      for (int time = 0; time < 5; ++time) {
+        std::shuffle(trackHits.begin(), trackHits.end(), engine);
+        
+        lar::util::TrackTimeInterval::TimeRange const& timeRange
+          = chargeTime.timeRangeOfHits(trackHits);
+        
+        std::cout << "[" << time << " ] Track from " << Xa << " to " << Xb
+          << " of drift: time range: " << timeRange << std::endl;
+        
+        BOOST_TEST(timeRange.duration().value() == timeSpan,
+                   boost::test_tools::tolerance(0.001));
+        
+      } // for shuffles
+      
+    } // for track positions
+    
+  } // for all TPC
+  
+} // BOOST_AUTO_TEST_CASE(PrintHitsOnAllPlanes)
+
+
+
+// BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This branch adds an utility `lar::util::TrackTimeInterval` which computes the range of time (in electronics time scale) compatible with the TPC tick of one or more hits.
The math is documented and quite simple — all the analysis decisions about margin are left to the users.

There is also an unrelated minor bug fix to `PlotSandbox` (on separate commit) that I am adding to the PR just because.

Reviewers... I would summon @JackSmedley but he's still too smart to fall into the trap of demanding registration to this group. So it's @brucehoward-physics... sorry. :grimacing: 