### PR TITLE
Renamed GSL header (gsl_util → util)

### DIFF
--- a/icarusalg/Utilities/SampledFunction.h
+++ b/icarusalg/Utilities/SampledFunction.h
@@ -16,7 +16,7 @@
 
 // C++ core guideline library
 #include "gsl/span"
-#include "gsl/gsl_util" // gsl::index
+#include "gsl/util" // gsl::index
 
 // C++ standard library
 #include <vector>


### PR DESCRIPTION
This is due maintenance to remove a new warning at compilation stage.

No matching production branch change is foreseen.