### PR TITLE
TimeIntervalConfig: utility to specify time intervals in FHiCL configuration

### DIFF
--- a/icarusalg/Utilities/TimeInterval.h
+++ b/icarusalg/Utilities/TimeInterval.h
@@ -1,0 +1,228 @@
+/**
+ * @file   icarusalg/Utilities/TimeInterval.h
+ * @brief  Simple time interval object.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 4, 2023
+ * 
+ * This library is header only.
+ */
+
+#ifndef ICARUSALG_UTILITIES_TIMEINTERVAL_H
+#define ICARUSALG_UTILITIES_TIMEINTERVAL_H
+
+
+// C/C++ standard libraries
+#include <ostream>
+#include <utility> // std::declval()
+#include <cstddef> // std::size_t
+
+
+//--------------------------------------------------------------------------
+namespace icarus::ns::util {
+  template <typename Time> struct TimeInterval;
+  
+  template <typename Time>
+  std::ostream& operator<< (std::ostream& out, TimeInterval<Time> const& time);
+  
+  /// Returns a new `interval` shifted by `shift` in the future.
+  template <typename TimeI, typename TimeS>
+  constexpr auto operator+ (TimeInterval<TimeI> const& interval, TimeS shift);
+
+  /// Returns a new `interval` shifted by `shift` in the future.
+  template <typename TimeI, typename TimeS>
+  constexpr auto operator+ (TimeS shift, TimeInterval<TimeI> const& interval);
+  
+  /// Returns a new `interval` shifted by `shift` in the past.
+  template <typename TimeI, typename TimeS>
+  constexpr auto operator- (TimeInterval<TimeI> const& interval, TimeS shift);
+  
+  template <std::size_t I, typename Time> Time get(TimeInterval<Time> const&);
+  template <std::size_t I, typename Time> Time& get(TimeInterval<Time>&);
+  
+} // namespace icarus::ns::util
+
+
+//--------------------------------------------------------------------------
+/**
+ * @brief Simple time interval, a `start` and a `stop` (of type `T`).
+ * @tparam Time type of time for the interval
+ * 
+ * This simple class is mostly a data structure for use with 
+ * `icarus::ns::fhicl::TimeIntervalConfig` to read a time interval from
+ * configuration.
+ * 
+ * It is designed with some care to allow custom data types like LArSoft time
+ * quantities, e.g. `TimeInterval<detinfo::timescales::electronics_time>`.
+ */
+template <typename Time>
+struct icarus::ns::util::TimeInterval {
+  
+  using Time_t = Time; ///< Type of time used.
+  
+  /// Type of time difference.
+  using TimeDiff_t = decltype(std::declval<Time_t>() - std::declval<Time_t>());
+  
+  Time_t start;         ///< Start time of the interval (included).
+  Time_t stop{ start }; ///< End time of the interval (excluded).
+  
+  
+  // --- BEGIN -- Constructors -------------------------------------------------
+  /// @name Constructors
+  /// @{
+  
+  /// Constructor: an empty interval.
+  TimeInterval() = default;
+  
+  TimeInterval(TimeInterval const&) = default;
+  
+  /// Constructor: sets an empty interval starting at `start` time.
+  constexpr TimeInterval(Time_t start): TimeInterval{ start, start } {}
+  
+  /// Constructor: sets start and stop time.
+  constexpr TimeInterval(Time_t start, Time_t stop)
+    : start{ start }, stop{ stop } {}
+  
+  /// Constructor: copies from other time interval types.
+  template <typename OtherType>
+  constexpr TimeInterval(TimeInterval<OtherType> const& other)
+    : TimeInterval{ other.start, other.stop } {}
+  
+  /// @}
+  // --- END ---- Constructors -------------------------------------------------
+  
+  
+  // --- BEGIN -- Query --------------------------------------------------------
+  /// @name Query
+  /// @{
+  
+  /// Returns whether the interval is empty.
+  constexpr bool empty() const noexcept { return start >= stop; }
+  
+  /// Returns the total length/duration of the interval.
+  constexpr TimeDiff_t duration() const noexcept { return stop - start; }
+  
+  /// @}
+  // --- END ---- Query --------------------------------------------------------
+  
+  
+  // --- BEGIN -- Operations ---------------------------------------------------
+  /// @name Simple algorithms
+  /// @{
+  
+  /// Returns whether `t` is between `start` (included) and `stop` (excluded).
+  constexpr bool contains(Time_t t) const noexcept
+    { return (t >= start) && (t < stop); }
+  
+  /// @}
+  // --- END ---- Operations ---------------------------------------------------
+  
+  
+  // --- BEGIN -- Modifiers ----------------------------------------------------
+  /// @name Modifiers
+  /// @{
+  
+  /// Adds the specified `amount` of time to the interval ends, if not empty.
+  template <typename OtherTime>
+  TimeInterval<Time_t>& shift(OtherTime amount)
+    { if (!empty()) { start += amount; stop += amount; } return *this; }
+  
+  /// Reduces this interval to its intersection with `other`.
+  template <typename OtherTime>
+  TimeInterval<Time_t>& intersect(TimeInterval<OtherTime> const& other)
+    {
+      if (start < other.start) start = other.start;
+      if (stop > other.stop) stop = other.stop;
+      return *this;
+    }
+  
+  /// Reduces this interval to its extension with `other`.
+  template <typename OtherTime>
+  TimeInterval<Time_t>& extend(TimeInterval<OtherTime> const& other)
+    {
+      if (empty()) *this = other;
+      else if (!other.empty()) {
+        if (other.start < start) start = other.start;
+        if (other.stop > stop) stop = other.stop;
+      }
+      return *this;
+    }
+  
+  /// Adds the specified `amount` of time to the interval ends, if not empty.
+  template <typename OtherTime>
+  TimeInterval<Time_t>& operator += (OtherTime amount)
+    { return shift(amount); }
+  
+  /// Subtracts a specified `amount` of time to the interval ends, if not empty.
+  template <typename OtherTime>
+  TimeInterval<Time_t>& operator -= (OtherTime amount)
+    { return shift(-amount); }
+  
+  /// @}
+  // --- END ---- Modifiers ----------------------------------------------------
+  
+}; // icarus::ns::util::TimeInterval
+
+
+//--------------------------------------------------------------------------
+//---  Template implementation
+//--------------------------------------------------------------------------
+template <typename TimeI, typename TimeS>
+constexpr auto icarus::ns::util::operator+
+  (icarus::ns::util::TimeInterval<TimeI> const& interval, TimeS shift)
+{
+  return TimeInterval{ interval.start + shift, interval.stop + shift };
+}
+
+template <typename TimeI, typename TimeS>
+constexpr auto icarus::ns::util::operator+
+  (TimeS shift, icarus::ns::util::TimeInterval<TimeI> const& interval)
+{
+  // note that Interval<> + Point<> is not supported, Point<>+Interval<> is
+  return TimeInterval{ shift + interval.start, shift + interval.stop };
+}
+
+
+template <typename TimeI, typename TimeS>
+constexpr auto icarus::ns::util::operator-
+  (icarus::ns::util::TimeInterval<TimeI> const& interval, TimeS shift)
+{
+  return TimeInterval{ interval.start - shift, interval.stop - shift };
+}
+
+
+//--------------------------------------------------------------------------
+template <typename Time>
+std::ostream& icarus::ns::util::operator<<
+  (std::ostream& out, TimeInterval<Time> const& time)
+{
+  if (time.empty()) out << "[ empty ]";
+  else out << "[ " << time.start << " ; " << time.stop << "]";
+  return out;
+}
+
+
+//--------------------------------------------------------------------------
+template <std::size_t I, typename Time>
+Time icarus::ns::util::get(TimeInterval<Time> const& interval) {
+  // this is written for when we'll use C++20
+  // (C++17 does not find this `get()` with argument-based lookup)
+  static_assert(I == 0 || I == 1, "Invalid index for get(TimeInterval)");
+  if constexpr(I == 0) return interval.start;
+  if constexpr(I == 1) return interval.stop;
+} // icarus::ns::util::get(TimeInterval)
+
+
+template <std::size_t I, typename Time>
+Time& icarus::ns::util::get(TimeInterval<Time>& interval) {
+  // this is written for when we'll use C++20
+  // (C++17 does not find this `get()` with argument-based lookup)
+  static_assert(I == 0 || I == 1, "Invalid index for get(TimeInterval)");
+  if constexpr(I == 0) return interval.start;
+  if constexpr(I == 1) return interval.stop;
+} // icarus::ns::util::get(TimeInterval)
+
+
+//--------------------------------------------------------------------------
+
+
+#endif // ICARUSALG_UTILITIES_TIMEINTERVAL_H

--- a/icarusalg/Utilities/TimeIntervalConfig.h
+++ b/icarusalg/Utilities/TimeIntervalConfig.h
@@ -1,0 +1,198 @@
+/**
+ * @file   icarusalg/Utilities/TimeIntervalConfig.h
+ * @brief  Helper for specifying a time interval parameter in FHiCL.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 4, 2023
+ * 
+ * This library is header only.
+ */
+
+#ifndef ICARUSALG_UTILITIES_TIMEINTERVALCONFIG_H
+#define ICARUSALG_UTILITIES_TIMEINTERVALCONFIG_H
+
+
+// ICARUS libraries
+#include "icarusalg/Utilities/TimeInterval.h"
+
+// framework libraries
+#include "fhiclcpp/types/OptionalTable.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <optional>
+
+
+//--------------------------------------------------------------------------
+namespace icarus::ns::fhicl {
+  
+  template <typename Time> struct TimeIntervalConfig;
+  
+  template <typename Time>
+  icarus::ns::util::TimeInterval<Time> makeTimeInterval
+    (TimeIntervalConfig<Time> const& config);
+  
+  template <typename Time>
+  std::optional<icarus::ns::util::TimeInterval<Time>> makeTimeInterval
+    (std::optional<TimeIntervalConfig<Time>> const& config);
+  
+  /**
+   * @brief FHiCL optional configuration object for specification of a (time)
+   *        interval.
+   * @tparam Time the type of the time point being read by the configuration
+   * @see `icarus::ns::fhicl::TimeIntervalConfig`
+   * 
+   * This is a handy alias for a FHiCL configuration with an optional
+   * `icarus::ns::fhicl::TimeIntervalConfig` entry.
+   * Note that since FHiCL tables do not support default values, this is the
+   * way to have one (see `icarus::ns::fhicl::TimeIntervalConfig` example).
+   * 
+   * Use it like in the FHiCL configuration object of an algorithm or module:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * using electronics_time = detinfo::timescales::electronics_time;
+   * 
+   * struct Config {
+   *   
+   *   using Name = fhicl::Name;
+   *   using Comment = fhicl::Comment;
+   *   
+   *   TimeIntervalTable<electronics_time> Interval{
+   *     Name{ "Interval" },
+   *     Comment{ "specify the selection time interval" }
+   *     };
+   *   
+   *   // ...
+   *   
+   * };
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  template <typename Time>
+  using TimeIntervalTable = ::fhicl::Table<TimeIntervalConfig<Time>> ;
+  
+  /**
+   * @brief FHiCL optional configuration object for specification of a (time)
+   *        interval.
+   * @tparam Time the type of the time point being read by the configuration
+   * @see `icarus::ns::fhicl::TimeIntervalConfig`
+   * 
+   * This is a handy alias for a FHiCL configuration with an optional
+   * `icarus::ns::fhicl::TimeIntervalConfig` entry.
+   * Note that since FHiCL tables do not support default values, this is the
+   * way to have one (see `icarus::ns::fhicl::TimeIntervalConfig` example).
+   * 
+   * Use it like in the FHiCL configuration object of an algorithm or module:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * using nanosecond = util::quantities::points::nanosecond;
+   * 
+   * struct Config {
+   *   
+   *   using Name = fhicl::Name;
+   *   using Comment = fhicl::Comment;
+   *   
+   *   TimeIntervalOptionalTable<nanosecond> Interval{
+   *     Name{ "Interval" },
+   *     Comment{ "override the selection time interval" }
+   *     };
+   *   
+   *   // ...
+   *   
+   * };
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  template <typename Time>
+  using TimeIntervalOptionalTable
+    = ::fhicl::OptionalTable<TimeIntervalConfig<Time>>;
+    
+} // namespace icarus::ns::fhicl
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief FHiCL configuration object for specification of a (time) interval.
+ * @tparam Time the type of the time point being read by the configuration
+ * 
+ * 
+ * 
+ */
+template <typename Time> 
+struct icarus::ns::fhicl::TimeIntervalConfig {
+  
+  using Name = ::fhicl::Name;
+  using Comment = ::fhicl::Comment;
+  
+  using TimeQuantity_t = Time; ///< Type of time being read.
+  
+  /// Type of time difference.
+  using Duration_t
+    = decltype(std::declval<TimeQuantity_t>() - std::declval<TimeQuantity_t>());
+  
+  
+  ::fhicl::OptionalAtom<TimeQuantity_t> Start{
+    Name{ "Start" },
+    Comment{ "start time [default: since forever]" }
+    };
+  
+  ::fhicl::OptionalAtom<TimeQuantity_t> End{
+    Name{ "End" },
+    Comment{ "end time [default: to forever]" }
+    };
+  
+  ::fhicl::OptionalAtom<Duration_t> Duration{
+    Name{ "Duration" },
+    Comment{ "interval duration [default: forever]" }
+    };
+  
+}; // icarus::ns::fhicl::TimeIntervalConfig
+
+
+//--------------------------------------------------------------------------
+// --- template implementation
+//--------------------------------------------------------------------------
+template <typename Time>
+icarus::ns::util::TimeInterval<Time> icarus::ns::fhicl::makeTimeInterval
+  (TimeIntervalConfig<Time> const& config)
+{
+  // start with default: -0 / +0 (empty):
+  icarus::ns::util::TimeInterval<Time> interval;
+  
+  if (config.Start()) {
+    interval.start = *(config.Start());
+    if (config.End()) {
+      interval.stop = *(config.End());
+      if (config.Duration()) {
+        throw cet::exception{ "makeTimeInterval" }
+          << "Only up to two among '" << config.Start.name() << "', '"
+          << config.End.name() << "' and '" << config.Duration.name()
+          << "' parameters must be specified for a time interval.\n";
+      }
+    }
+    else if (config.Duration()) {
+      interval.stop = interval.start + *(config.Duration());
+    }
+  }
+  else if (config.End()) {
+    interval.stop = *(config.End());
+    if (config.Duration())
+      interval.start = interval.stop - *(config.Duration());
+  }
+  else if (config.Duration()) {
+    interval.stop = interval.start + *(config.Duration());
+  }
+  
+  return interval;
+} // icarus::ns::fhicl::makeTimeInterval()
+
+
+//--------------------------------------------------------------------------
+template <typename Time>
+std::optional<icarus::ns::util::TimeInterval<Time>>
+icarus::ns::fhicl::makeTimeInterval
+  (std::optional<TimeIntervalConfig<Time>> const& config)
+  { return config? std::optional{ makeTimeInterval(*config) }: std::nullopt; }
+
+
+//--------------------------------------------------------------------------
+
+
+#endif // ICARUSALG_UTILITIES_TIMEINTERVALCONFIG_H


### PR DESCRIPTION
This is a small utility that allows in a few line of codes to specify in FHiCL configuration time intervals like
```
BeamGate: {  Start: "1.5 ms"  Duration: "9.6 us"  }
```
or
```
SelectTime: {  Start: "-40 ns"  End: "+10 ns"  }
```
etc.
One of my branches using it is already in pull request, another will come soon.

Reviewers: I don't know... it's just a piece of library code.