### PR TITLE
Fixed typo in documentation

### DIFF
--- a/icarusalg/Utilities/TrackTimeInterval.h
+++ b/icarusalg/Utilities/TrackTimeInterval.h
@@ -55,7 +55,7 @@ namespace lar::util {
  * result, `TimeRange`, pointedly and deliberately includes arguments for
  * margins).
  * 
- * Despite the "track` in the name, the interface allows to specify a collection
+ * Despite the "track" in the name, the interface allows to specify a collection
  * of hits, or hit times, but not a `recob::Track` (associated hits needs to be
  * discovered before the call).
  * 


### PR DESCRIPTION
It's amazing how much fuzz Doxygen can make for a single unmatched backtick.

Do we need a review for this commit?
It may be the shortest one in LArSoft history.