### PR TITLE
Various updates to icarusalg algorithms

### DIFF
--- a/icarusalg/Utilities/CommonChoiceSelectors.cxx
+++ b/icarusalg/Utilities/CommonChoiceSelectors.cxx
@@ -1,0 +1,50 @@
+/**
+ * @file   icarusalg/Utilities/CommonChoiceSelectors.cxx
+ * @brief  Selector implementations for some enumerator data types.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 18, 2023
+ * @see    icarusalg/Utilities/CommonChoiceSelectors.h
+ */
+
+
+// library header
+#include "icarusalg/Utilities/CommonChoiceSelectors.h"
+
+// framework libraries
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <string>
+#include <set>
+
+
+//==============================================================================
+//===  util::TimeScale  ========================================================
+//==============================================================================
+//------------------------------------------------------------------------------
+//--- util::StandardSelectorFor<TimeScale>
+//------------------------------------------------------------------------------
+namespace util {
+  
+  StandardSelectorFor<util::TimeScale>::StandardSelectorFor()
+    : MultipleChoiceSelection<util::TimeScale>{
+        { TimeScale::Electronics, "Electronics", "ElectronicsTime" }
+      , { TimeScale::Trigger,     "Trigger",     "TriggerTime" }
+      , { TimeScale::BeamGate,    "BeamGate",    "Beam", "BeamGateTime" }
+      , { TimeScale::Simulation,  "Simulation",  "SimulationTime" }
+      }
+    {}
+}
+
+//------------------------------------------------------------------------------
+::fhicl::detail::ps_atom_t util::encode(TimeScale const& value) {
+  return util::details::encodeEnumClassToFHiCL(value);
+}
+
+//------------------------------------------------------------------------------
+void util::decode(std::any const& src, TimeScale& value) {
+  util::details::decodeEnumClassToFHiCL(src, value);
+}
+
+//------------------------------------------------------------------------------

--- a/icarusalg/Utilities/CommonChoiceSelectors.h
+++ b/icarusalg/Utilities/CommonChoiceSelectors.h
@@ -1,0 +1,93 @@
+/**
+ * @file   icarusalg/Utilities/CommonChoiceSelectors.h
+ * @brief  Selector implementations for some enumerator data types.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 18, 2023
+ * @see    icarusalg/Utilities/CommonChoiceSelectors.cxx
+ */
+
+
+#ifndef ICARUSALG_UTILITIES_COMMONCHOICESELECTORS_H
+#define ICARUSALG_UTILITIES_COMMONCHOICESELECTORS_H
+
+// SBN libraries
+#include "icarusalg/Utilities/StandardSelectorFor.h"
+
+/// LArSoft libraries
+#include "lardataalg/Utilities/MultipleChoiceSelection.h"
+
+/// framework libraries
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard library
+#include <type_traits> // std::enable_if_t
+
+
+// -----------------------------------------------------------------------------
+// --- BEGIN --- util::TimeScale -----------------------------------------------
+// -----------------------------------------------------------------------------
+/// @name util::TimeScale
+/// @{
+
+namespace util {
+  
+  /**
+   * @brief Expresses the choice of a time scale.
+   * 
+   * Time scales are documented in @ref DetectorClocksTimeDefinitions "LArSoft".
+   * The more friendly way to manipulate them is arguably via the
+   * `detinfo::DetectorTimings` helper.
+   * 
+   * This enumerator lists possible time scales for use in the code and in
+   * configuration (see `util::TimeScaleSelector`).
+   * 
+   */
+  enum class TimeScale: unsigned int {
+    Electronics, ///< @ref DetectorClocksElectronicsTime "Electronics time".
+    Trigger,     ///< @ref DetectorClocksTriggerTime "Hardware trigger time".
+    BeamGate,    ///< @ref DetectorClocksBeamGateTime "Beam gate opening time".
+    Simulation,  ///< @ref DetectorClocksSimulationTime "Simulation time".
+    
+    NTimes,      ///< Number of supported reference times.
+    Default = Electronics ///< LArSoft "default".
+  }; // TimeScale
+  
+  
+  // ---------------------------------------------------------------------------
+  /// Helper for generic encoding of `TimeScale` enumerator in FHiCL.
+  ::fhicl::detail::ps_atom_t encode(TimeScale const& value);
+
+  /// Helper for generic deecoding of `TimeScale` enumerator in FHiCL.
+  void decode(std::any const& src, TimeScale& value);
+  
+  // ---------------------------------------------------------------------------
+  /// Selector for `util::TimeScale` enumerator (template specialization).
+  template <>
+  struct StandardSelectorFor<TimeScale> // standard: `Tag` == `0`
+    : public MultipleChoiceSelection<util::TimeScale>
+  {
+    /// Constructor: initializes with some appropriate strings.
+    StandardSelectorFor();
+  }; // StandardSelectorFor<TimeScale>
+  
+  // ---------------------------------------------------------------------------
+  
+} // util
+
+namespace fhicl {
+  
+  /// Specialization of fhicl::Atom<>
+  template <>
+  struct Atom<::util::TimeScale>: SelectorAtom<::util::TimeScale> {
+    using SelectorAtom<::util::TimeScale>::SelectorAtom;
+  };
+  
+}
+
+
+/// @}
+
+// --- END ----- util::TimeScale -----------------------------------------------
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_UTILITIES_COMMONCHOICESELECTORS_H

--- a/icarusalg/Utilities/GroupByIndex.h
+++ b/icarusalg/Utilities/GroupByIndex.h
@@ -1,0 +1,155 @@
+/**
+ * @file   icarusalg/Utilities/GroupByIndex.h
+ * @brief  Algorithm to cluster objects according to their index.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 7, 2023
+ *
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSALG_UTILITIES_GROUPBYINDEX_H
+#define ICARUSALG_UTILITIES_GROUPBYINDEX_H
+
+
+// C/C++ standard libraries
+#include <vector>
+#include <utility> // std::forward()
+#include <cstddef> // std::size_t
+
+//------------------------------------------------------------------------------
+namespace icarus::ns::util {
+  template <typename T> class GroupByIndex;
+  
+  // deduction guide
+  template <typename Coll, typename KeyFunc>
+  GroupByIndex(Coll const&, KeyFunc&&)
+    -> GroupByIndex<typename Coll::value_type>;
+  
+} // namespace icarus::ns::util
+
+/**
+ * @brief Creates a map of objects grouped by an index
+ * @tparam T type of the objects to group
+ * 
+ * This class keeps a "map" of objects grouped by an "index".
+ * The index is supposed to be an integer whose value ranges from `0` to some
+ * number; a list of objects is allocated for each of the `N` indices.
+ * 
+ * Each group is implemented as a vector (`std::vector`) of pointers to the
+ * original data. _These groups are valid only as long as the original data is
+ * accessible._
+ * 
+ * Access is valid for any index, even `N` and above; in the latter cases, a
+ * prepacked empty list is returned.
+ * 
+ * The map is defined on construction and can't be modified afterwards.
+ * Also the pointed original objects can't be modified via the pointers from
+ * this map.
+ * While it is required to specify the method to extract a grouping index out of
+ * an object of type `T`, this extraction function is only used during the
+ * construction and it's not kept with the map.
+ * 
+ * Example:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * auto const& waveforms
+ *   = event.getProduct<std::vector<raw::OpDetWaveform>>("daqPMT");
+ * 
+ * icarus::ns::util::GroupByIndex byChannel
+ *  { waveforms, std::mem_fn(&raw::OpDetWaveform::ChannelNumber) };
+ * 
+ * for (std::vector<raw::OpDetWaveform const*> const& chWf: byChannel) {
+ *   if (chWf.empty()) continue;
+ *   std::cout << "Channel " << chWf.front()->ChannelNumber() << ": "
+ *     << chWf.size() << " waveforms" << std::endl;
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ */
+template <typename T>
+class icarus::ns::util::GroupByIndex {
+  
+    public:
+  
+  using Object_t = T; ///< Type of the object being grouped.
+  
+  /// Collection of objects (as non-mutable pointers to the original position).
+  using ObjectPtrColl_t = std::vector<Object_t const*>;
+  using size_type = typename std::vector<ObjectPtrColl_t>::size_type;
+  using const_iterator = typename std::vector<ObjectPtrColl_t>::const_iterator;
+  
+  /**
+   * @brief Constructor: groups the elements of the collection.
+   * @tparam Coll type of collection of objects of type `T`
+   * @tparam KeyFunc type of functor to extract an index from object of type `T`
+   * @param coll collection of objects of type `T` to be grouped
+   * @param extractKey functor extracting an index from an object of type `T`
+   */
+  template <typename Coll, typename KeyFunc>
+  GroupByIndex(Coll const& coll, KeyFunc&& extractKey)
+    : fMap{ buildMap(coll, std::forward<KeyFunc>(extractKey)) } {}
+  
+  /// Returns the list of objects in the specified group `index`.
+  ObjectPtrColl_t const& operator[] (std::size_t index) const
+    { return (index < size())? fMap[index]: EmptyGroup; }
+  
+  /// Returns whether there is at least one entry in the map.
+  bool empty() const noexcept { return fMap.empty(); }
+  
+  /// Returns the number of groups in the map (including empty ones).
+  size_type size() const noexcept { return fMap.size(); }
+  
+  /**
+   * @name Iterators
+   * 
+   * All functions return constant iterators whose value type is
+   * `ObjectPtrColl_t`.
+   */
+  /// @{
+  const_iterator begin() const { return cbegin(); }
+  const_iterator cbegin() const { return fMap.cbegin(); }
+  const_iterator end() const { return cend(); }
+  const_iterator cend() const { return fMap.cend(); }
+  /// @}
+  
+    private:
+  
+  static ObjectPtrColl_t const EmptyGroup;
+  
+  std::vector<ObjectPtrColl_t> fMap; ///< Internal representation of the map.
+  
+  /// Groups the data and returns the underlying map.
+  template <typename Coll, typename KeyFunc>
+  static std::vector<ObjectPtrColl_t> buildMap
+    (Coll const& coll, KeyFunc&& extractKey);
+  
+}; // icarus::ns::util::GroupByIndex
+
+
+// -----------------------------------------------------------------------------
+// --- Template implementation
+// -----------------------------------------------------------------------------
+template <typename T>
+typename icarus::ns::util::GroupByIndex<T>::ObjectPtrColl_t const
+icarus::ns::util::GroupByIndex<T>::EmptyGroup;
+
+
+// -----------------------------------------------------------------------------
+template <typename T>
+template <typename Coll, typename KeyFunc>
+auto icarus::ns::util::GroupByIndex<T>::buildMap
+  (Coll const& coll, KeyFunc&& extractKey) -> std::vector<ObjectPtrColl_t>
+{
+  std::vector<ObjectPtrColl_t> map;
+  
+  auto const accessMap = [&map](std::size_t index) -> ObjectPtrColl_t&
+    { if (index >= map.size()) map.resize(index + 1); return map[index]; };
+  
+  for (Object_t const& obj: coll) accessMap(extractKey(obj)).push_back(&obj);
+  
+  return map;
+} // icarus::ns::util::GroupByIndex<>::buildMap()
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSALG_UTILITIES_GROUPBYINDEX_H

--- a/icarusalg/Utilities/StandardSelectorFor.h
+++ b/icarusalg/Utilities/StandardSelectorFor.h
@@ -12,6 +12,7 @@
 
 
 /// LArSoft libraries
+#include <limits> // FIXME workaround until lardataalg PR #48 (https://github.com/LArSoft/lardataalg/pull/48) is adopted
 #include "lardataalg/Utilities/MultipleChoiceSelection.h"
 
 /// framework libraries
@@ -20,7 +21,6 @@
 // C/C++ standard library
 #include <any>
 #include <string>
-#include <limits> // FIXME workaround until lardataalg PR #48 (https://github.com/LArSoft/lardataalg/pull/48) is adopted
 #include <type_traits> // std::enable_if_t
 #include <cstddef> // std::size_t
 

--- a/icarusalg/Utilities/StandardSelectorFor.h
+++ b/icarusalg/Utilities/StandardSelectorFor.h
@@ -20,6 +20,7 @@
 // C/C++ standard library
 #include <any>
 #include <string>
+#include <limits> // FIXME workaround until lardataalg PR #48 (https://github.com/LArSoft/lardataalg/pull/48) is adopted
 #include <type_traits> // std::enable_if_t
 #include <cstddef> // std::size_t
 

--- a/icarusalg/Utilities/StandardSelectorFor.h
+++ b/icarusalg/Utilities/StandardSelectorFor.h
@@ -1,0 +1,419 @@
+/**
+ * @file   icarusalg/Utilities/StandardSelectorFor.h
+ * @brief  Selector infrastructure for some enumerator data types.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 18, 2023
+ * @see    icarusalg/Utilities/CommonChoiceSelectors.h
+ */
+
+
+#ifndef ICARUSALG_UTILITIES_STANDARDSELECTORFOR_H
+#define ICARUSALG_UTILITIES_STANDARDSELECTORFOR_H
+
+
+/// LArSoft libraries
+#include "lardataalg/Utilities/MultipleChoiceSelection.h"
+
+/// framework libraries
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard library
+#include <any>
+#include <string>
+#include <type_traits> // std::enable_if_t
+#include <cstddef> // std::size_t
+
+
+namespace util {
+  
+  // --- BEGIN ---  Enumerator selector implementation helpers -----------------
+  /**
+   * @name Enumerator selector implementation helpers
+   * 
+   * These helpers streamline some aspects of the implementation of FHiCL
+   * objects to read enumerators.
+   * 
+   * The enumerator, commonly labelled as `EnumClass`, must be _scoped_
+   * (`enum class`), so that its values carry a specific type (unscoped `enum`
+   * values are immediately converted to integral values).
+   * 
+   * The idea is to be able to just write things like:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * struct Config {
+   * 
+   *   fhicl::Atom<ns::ValueTypeEnum> ValueType {
+   *     fhicl::Name{ "ValueType" },
+   *     fhicl::Comment{ "type of value" },
+   *     ns::ValueTypeEnum::Integral
+   *     };
+   * 
+   * };
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * and then read it as:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * ns::ValueTypeEnum valueType = config.ValueType();
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * 
+   * This requires the code to know how to convert a string into a enumerator
+   * value and vice versa. This is usually done via `encode()` and `decode()`
+   * free functions that the FHiCL library looks for. In fact, the library
+   * deliberately does not specify which namespace to find them in: the
+   * expectation is that they are available in the same namespace as the objects
+   * they code (the alternatives would be in the `::fhicl` namespace, which we
+   * consider reserved to the library, and the global namespace, which we don't
+   * want to populate). Since we don't require the enumerators to be in any
+   * specific namespace, the two functions must be provided by the user.
+   * This library provides an implementation that can be directly used:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * ::fhicl::detail::ps_atom_t ns::encode(ValueTypeEnum const& value) {
+   *   return ::util::encodeEnumClassToFHiCL(value);
+   * }
+   * 
+   * void ns::decode(std::any const& src, ValueTypeEnum& value) {
+   *   ::util::decodeEnumClassToFHiCL(src, value);
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * The two helpers here utilize indirectly objects of type
+   * `util::MultipleChoiceSelection<EnumClass>` to implement.
+   * These objects require the names of the enumerator values at initialization
+   * time, so they can't be written in generic code.
+   * The helpers above rely on an object of type `util::StandardSelectorFor`
+   * (in namespace `util`) which acts like a fully-initialized
+   * `util::MultipleChoiceSelection` object. For example:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * namespace util {
+   *   template <>
+   *   struct StandardSelectorFor<ns::ValueTypeEnum>
+   *     : public util::MultipleChoiceSelection<ns::ValueTypeEnum>
+   *   {
+   *     StandardSelectorFor()
+   *       : MultipleChoiceSelection<ns::ValueTypeEnum>{
+   *           { ns::ValueTypeEnum::Integer,    "Integer",    "int" }
+   *         , { ns::ValueTypeEnum::NonInteger, "NonInteger", "other" }
+   *         }
+   *       {}
+   *   };
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * 
+   * Different versions of `util::StandardSelectorFor` can be specified for the
+   * same enumerator by changing the template parameter `Tag` (which is not
+   * shown in the example and defaults to `0`) for both the class and the
+   * `encode()`/`decode()` functions.
+   * 
+   * Note that the type of override of `util::StandardSelectorFor` required here
+   * is a template specialization. The specialization needs to be visible to the
+   * code before the point where it's needed, or else a less specialized version
+   * of the class will be used; in this case, the generic
+   * `util::StandardSelectorFor` is written to generate a compilation error,
+   * although the error message will be not so straightforward to interpret.
+   * 
+   */
+  /// @{
+  
+  /**
+   * @brief A selector specific for `EnumClass`.
+   * @tparam EnumClass enumerator type the selector wraps around
+   * @tparam Tag (default: `0`) a value to distinguish different selectors
+   * 
+   * A `StandardSelectorFor` is a class derived from
+   * `util::MultipleChoiceSelection` which contains a construction specific for
+   * `EnumClass` enumerator type.
+   * 
+   * The idea is that generic code can initialize a `StandardSelectorFor<>`
+   * object and expect it correctly set up.
+   * 
+   * @note Because the initialization is specific to `EnumClass`, the generic
+   *       template can't work and it is provided here only to document the
+   *       "interface". Specializations are _required_ for each `EnumClass`
+   *       that needs support, and this specialization may reside in their
+   *       own header which won't be automatically included together with
+   *       this class. If no suitable specialization is found, this template
+   *       will be tried in `encodeEnumClassToFHiCL()` etc., which will cause
+   *       a compilation error about failing to match the template arguments
+   *       of `StandardSelectorFor` or having `hasStandardSelector_v` false.
+   *       In that case, make sure that the header file with the declaration of
+   *       the specialization is included before it's needed.
+   * 
+   * An additional template parameter, `Tag`, is provided in case generic code
+   * wants to support different types of selectors for the same type (for
+   * example, some excluding part of the available enumerator values).
+   * The "standard" `Tag` value `0` is supposed to be... well, "standard".
+   */
+  template <typename EnumClass, std::size_t Tag = 0>
+  struct StandardSelectorFor { static constexpr bool isEnumSupported = false; };
+  
+  template <typename EnumClass, std::size_t Tag = 0, typename Enable = void>
+  struct hasStandardSelector_t: std::true_type {};
+  
+  /// Whether `EnumType` has a specialised standard selector class.
+  template <typename EnumType, std::size_t Tag = 0>
+  constexpr bool hasStandardSelector_v = hasStandardSelector_t<EnumType, Tag>();
+  
+  
+  namespace details {
+    
+    /**
+     * @brief Encodes a enumerator value for a FHiCL atom.
+     * 
+     * This is the recommended hook/implementation of an actual `encode()`
+     * function:
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+     * namespace myns {
+     *   auto encode(myns::MyEnumClass const& value)
+     *     { return util::details::encodeEnumClassToFHiCL(value); }
+     * }
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * This indirection is needed so that FHiCL machinery can find the
+     * `encode()` function in the same namespace where the enumerator is defined
+     * (in the example, `myns`).
+     */
+    template <std::size_t Tag = 0, typename EnumClass>
+    std::enable_if_t
+      <hasStandardSelector_v<EnumClass, Tag>, ::fhicl::detail::ps_atom_t>
+    encodeEnumClassToFHiCL(EnumClass const& value);
+    
+    template <std::size_t Tag = 0, typename EnumClass>
+    std::enable_if_t<util::hasStandardSelector_v<EnumClass, Tag>>
+    decodeEnumClassToFHiCL(std::any const& src, EnumClass& value);
+    
+  } // namespace details
+  
+  
+  /// @}
+  // --- END -----  Enumerator selector implementation helpers -----------------
+} // namespace util
+
+
+// -----------------------------------------------------------------------------
+
+
+namespace fhicl {
+  
+  // ---------------------------------------------------------------------------
+  /*
+   * Because `fhiclcpp` classes are declared `final`, we can't customize them
+   * by inheritance; overloading `encode()`/`decode()` helps but does not do
+   * the full work (in particular the default value management is not covered).
+   * Containment would require making sure that the containing class support
+   * all the FHiCL validation machinery and then replicates all the needed
+   * user interface.
+   * 
+   * So I end up specializing a class and inheriting from implementation details
+   * which may change at any time.
+   */
+  template <typename T>
+  class SelectorAtom
+    : public detail::AtomBase
+    , private detail::RegisterIfTableMember
+  {
+    static_assert(util::hasStandardSelector_v<T>);
+      public:
+    static_assert(!tt::is_sequence_type_v<T>, NO_STD_CONTAINERS);
+    static_assert(!tt::is_fhicl_type_v<T>, NO_NESTED_FHICL_TYPES_IN_ATOM);
+    static_assert(!tt::is_table_fragment_v<T>, NO_NESTED_TABLE_FRAGMENTS);
+    static_assert(!tt::is_delegated_parameter_v<T>, NO_DELEGATED_PARAMETERS);
+    
+    //=====================================================
+    // User-friendly
+    // ... c'tors
+    explicit SelectorAtom(Name&& name);
+    explicit SelectorAtom(Name&& name, Comment&& comment);
+    explicit SelectorAtom(Name&& name, Comment&& comment, std::function<bool()> useIf);
+
+    // ... c'tors supporting defaults
+    explicit SelectorAtom(Name&& name, T const& dflt_value);
+    explicit SelectorAtom(Name&& name, Comment&& comment, T const& dflt_value);
+    explicit SelectorAtom(
+      Name&& name, Comment&& comment,
+      std::function<bool()> useIf, T const& dflt_value
+      );
+
+    // ... Accessors
+    auto const&
+    operator()() const
+    {
+      return value_;
+    }
+
+    // Expert-only
+    using default_type = T;
+    using value_type = T;
+
+  private:
+    value_type value_{};
+
+    static ::util::StandardSelectorFor<T> const selector;
+    
+    SelectorAtom(
+      Name&& name, Comment&& comment, par_style const vt,
+      std::function<bool()> maybeUse, T dflt_value = T{}
+      );
+    
+    std::string get_stringified_value() const override;
+    void do_set_value(fhicl::ParameterSet const& pset) override;
+    
+  }; // class SelectorAtom
+  
+} // fhicl
+
+
+// =============================================================================
+// ===  Template implementation
+// =============================================================================
+// -----------------------------------------------------------------------------
+// --- FHiCL encoding/decoding implementation
+// -----------------------------------------------------------------------------
+/*
+ * Somehow unusual, and I hope it works.
+ * By default, all types are considered to have a standard selector.
+ * The ones that can instantiate the following specialization are the exception.
+ * All the ones which have `EnumClass` not an `enum class` fall in that category
+ * (unfortunately until C++23 we won't know directly whether they are a scoped
+ * or unscoped enumerator, so I am checking that it is an enumerator and that it
+ * can't be converted into an integer, as in
+ * https://stackoverflow.com/questions/15586163/c11-type-trait-to-differentiate-between-enum-class-and-regular-enum).
+ * In addition, all the ones that are `enum class` and do have a specialization
+ * of `util::StandardSelectorFor` which tells the enum is not supported also
+ * fall in that category. Now, the main template does exactly that: says that
+ * the argument is not supported (it also means that the check whether
+ * `EnumClass` is an enumerator or not is redundant).
+ * 
+ * If on the other end there is a specialization of `util::StandardSelectorFor`
+ * for a scoped enumerator `EnumClass`, and it does not specify
+ * `isEnumSupported`, then that enumerator does not fall in this category of
+ * unsupported enumerators. And if it does specify `isEnumSupported`, and
+ * it converts to `false`... well, I don't know what to say.
+ * Implementer's choice.
+ */
+template <typename EnumClass, std::size_t Tag>
+struct util::hasStandardSelector_t<EnumClass, Tag,
+  std::enable_if_t<
+    !std::is_enum_v<EnumClass> || std::is_convertible_v<EnumClass, int>
+    || !util::StandardSelectorFor<EnumClass>::isEnumSupported
+  >>
+  : std::false_type
+{};
+
+
+// -----------------------------------------------------------------------------
+template <std::size_t Tag /* = 0 */, typename EnumClass>
+std::enable_if_t
+  <util::hasStandardSelector_v<EnumClass, Tag>, ::fhicl::detail::ps_atom_t>
+util::details::encodeEnumClassToFHiCL(EnumClass const& value) {
+  static util::StandardSelectorFor<EnumClass, Tag> const selector;
+  return ::fhicl::detail::encode(selector.get(value).name());
+} // util::details::encodeEnumClassToFHiCL()
+
+
+// -----------------------------------------------------------------------------
+template <std::size_t Tag /* = 0 */, typename EnumClass>
+std::enable_if_t<util::hasStandardSelector_v<EnumClass, Tag>>
+util::details::decodeEnumClassToFHiCL(std::any const& src, EnumClass& value) {
+  std::string s;
+  ::fhicl::detail::decode(src, s);
+  static util::StandardSelectorFor<EnumClass, Tag> const selector;
+  value = selector.parse(s).value();
+} // util::details::decodeEnumClassToFHiCL()
+
+
+// -----------------------------------------------------------------------------
+// ---  fhicl::SelectorAtom<>
+// -----------------------------------------------------------------------------
+template <typename T>
+util::StandardSelectorFor<T> const fhicl::SelectorAtom<T>::selector;
+
+// -----------------------------------------------------------------------------
+template <typename T>
+fhicl::SelectorAtom<T>::SelectorAtom(Name&& name, Comment&& comment)
+  : SelectorAtom{
+    std::move(name), std::move(comment),
+    par_style::REQUIRED, detail::AlwaysUse()
+  }
+  {}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+fhicl::SelectorAtom<T>::SelectorAtom
+  (Name&& name, Comment&& comment, std::function<bool()> maybeUse)
+  : SelectorAtom{
+    std::move(name), std::move(comment),
+    par_style::REQUIRED_CONDITIONAL, maybeUse
+  }
+  {}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+fhicl::SelectorAtom<T>::SelectorAtom
+  (Name&& name, Comment&& comment, T const& dflt_value)
+  : SelectorAtom{
+    std::move(name), std::move(comment),
+    par_style::DEFAULT, detail::AlwaysUse(), dflt_value
+  }
+  {}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+fhicl::SelectorAtom<T>::SelectorAtom(
+  Name&& name, Comment&& comment,
+  std::function<bool()> maybeUse, T const& dflt_value
+)
+  : SelectorAtom{
+    std::move(name), Comment{ "" },
+    par_style::DEFAULT_CONDITIONAL, maybeUse, dflt_value
+  }
+  {}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+fhicl::SelectorAtom<T>::SelectorAtom(Name&& name)
+  : SelectorAtom{ std::move(name), Comment("") }
+  {}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+fhicl::SelectorAtom<T>::SelectorAtom(Name&& name, T const& dflt_value)
+  : SelectorAtom{ std::move(name), Comment(""), dflt_value }
+  {}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+std::string fhicl::SelectorAtom<T>::get_stringified_value() const {
+  return has_default()
+    ? selector.get(value_).name()
+    : detail::no_defaults::expected_types<T>{}.value
+    ;
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+fhicl::SelectorAtom<T>::SelectorAtom(
+  Name&& name, Comment&& comment, par_style const vt,
+  std::function<bool()> maybeUse, T dflt_value /* = T{} */
+)
+  : AtomBase{ std::move(name), std::move(comment), vt, maybeUse }
+  , RegisterIfTableMember{this}
+  , value_{ std::move(dflt_value) }
+{
+  NameStackRegistry::end_of_ctor();
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void fhicl::SelectorAtom<T>::do_set_value(fhicl::ParameterSet const& pset)
+{
+  auto const trimmed_key = detail::strip_first_containing_name(key());
+  if (has_default()) {
+    // Override default value if the key is present
+    pset.get_if_present<T>(trimmed_key, value_);
+  }
+  else
+    value_ = pset.get<T>(trimmed_key);
+}
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSALG_UTILITIES_STANDARDSELECTORFOR_H
+
+// =============================================================================

--- a/icarusalg/Utilities/StandardSelectorFor.h
+++ b/icarusalg/Utilities/StandardSelectorFor.h
@@ -170,7 +170,7 @@ namespace util {
      */
     template <std::size_t Tag = 0, typename EnumClass>
     std::enable_if_t
-      <hasStandardSelector_v<EnumClass, Tag>, ::fhicl::detail::ps_atom_t>
+      <util::hasStandardSelector_v<EnumClass, Tag>, ::fhicl::detail::ps_atom_t>
     encodeEnumClassToFHiCL(EnumClass const& value);
     
     template <std::size_t Tag = 0, typename EnumClass>

--- a/icarusalg/Utilities/TimeInterval.h
+++ b/icarusalg/Utilities/TimeInterval.h
@@ -17,7 +17,7 @@
 #include <cstddef> // std::size_t
 
 
-//--------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 namespace icarus::ns::util {
   template <typename Time> struct TimeInterval;
   
@@ -42,7 +42,7 @@ namespace icarus::ns::util {
 } // namespace icarus::ns::util
 
 
-//--------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /**
  * @brief Simple time interval, a `start` and a `stop` (of type `T`).
  * @tparam Time type of time for the interval
@@ -71,9 +71,7 @@ struct icarus::ns::util::TimeInterval {
   /// @{
   
   /// Constructor: an empty interval.
-  TimeInterval() = default;
-  
-  TimeInterval(TimeInterval const&) = default;
+  constexpr TimeInterval() = default;
   
   /// Constructor: sets an empty interval starting at `start` time.
   constexpr TimeInterval(Time_t start): TimeInterval{ start, start } {}

--- a/icarusalg/Utilities/TimeIntervalConfig.h
+++ b/icarusalg/Utilities/TimeIntervalConfig.h
@@ -13,6 +13,8 @@
 
 // ICARUS libraries
 #include "icarusalg/Utilities/TimeInterval.h"
+#include "lardataalg/Utilities/intervals_fhicl.h" // convenience
+#include "lardataalg/Utilities/quantities_fhicl.h" // convenience
 
 // framework libraries
 #include "fhiclcpp/types/OptionalTable.h"
@@ -27,26 +29,57 @@
 //--------------------------------------------------------------------------
 namespace icarus::ns::fhicl {
   
+  /**
+   * @brief FHiCL configuration for a `icarus::ns::util::TimeInterval` object.
+   * @tparam Time type of time the interval object uses
+   * @see `icarus::ns::fhicl::TimeIntervalTable`,
+   *      `icarus::ns::fhicl::TimeIntervalOptionalTable`
+   * 
+   * Objects from this class can be included in the validated FHiCL
+   * configuration objects. See `icarus::ns::fhicl::TimeIntervalTable`
+   * and `icarus::ns::fhicl::TimeIntervalOptionalTable` for usage examples.
+   */
   template <typename Time> struct TimeIntervalConfig;
   
+  /**
+   * @brief Extracts a `icarus::ns::util::TimeInterval` value from a FHiCL
+   *        configuration.
+   * @tparam Time type of time the interval object uses
+   * @param config the FHiCL configuration to read the interval from
+   * @return an interval object
+   * @see `icarus::ns::fhicl::TimeIntervalTable`
+   * 
+   * See `icarus::ns::fhicl::TimeIntervalTable` for an usage example.
+   */
   template <typename Time>
   icarus::ns::util::TimeInterval<Time> makeTimeInterval
     (TimeIntervalConfig<Time> const& config);
   
+  /**
+   * @brief Extracts a `icarus::ns::util::TimeInterval` value from an optional
+   *        FHiCL configuration.
+   * @tparam Time type of time the interval object uses
+   * @param config the optional FHiCL configuration to read the interval from
+   * @return an optional interval object, `std::nullopt` if not in `config`
+   * @see `icarus::ns::fhicl::TimeIntervalOptionalTable`
+   * 
+   * This object can also be used as a way to supply a default value to a
+   * `icarus::ns::util::TimeInterval` parameter.
+   * See `icarus::ns::fhicl::TimeIntervalOptionalTable` for an usage example.
+   */
   template <typename Time>
   std::optional<icarus::ns::util::TimeInterval<Time>> makeTimeInterval
     (std::optional<TimeIntervalConfig<Time>> const& config);
   
   /**
-   * @brief FHiCL optional configuration object for specification of a (time)
-   *        interval.
+   * @brief FHiCL configuration object for specification of a (time) interval.
    * @tparam Time the type of the time point being read by the configuration
    * @see `icarus::ns::fhicl::TimeIntervalConfig`
    * 
-   * This is a handy alias for a FHiCL configuration with an optional
+   * This is a handy alias for a FHiCL configuration with a
    * `icarus::ns::fhicl::TimeIntervalConfig` entry.
-   * Note that since FHiCL tables do not support default values, this is the
-   * way to have one (see `icarus::ns::fhicl::TimeIntervalConfig` example).
+   * Note that FHiCL tables do not support default values, and to get something
+   * similar to it `TimeIntervalOptionalTable` can be used instead.
    * 
    * Use it like in the FHiCL configuration object of an algorithm or module:
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
@@ -66,6 +99,47 @@ namespace icarus::ns::fhicl {
    *   
    * };
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * 
+   * It can be read for example in the constructor of a class (e.g. a module):
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * class MyAlgorithm {
+   * 
+   *     public:
+   *   
+   *   using electronics_time = detinfo::timescales::electronics_time;
+   *   
+   *   struct Config {
+   *     
+   *     using Name = fhicl::Name;
+   *     using Comment = fhicl::Comment;
+   *     
+   *     icarus::ns::fhicl::TimeIntervalTable<electronics_time> Interval{
+   *       Name{ "Interval" },
+   *       Comment{ "specify the selection time interval" }
+   *       };
+   *     
+   *   };
+   *   
+   *   using Parameters = fhicl::Table<Config>;
+   *   
+   *   MyAlgorithm(Parameters const& params)
+   *     : fInterval
+   *       { icarus::ns::fhicl::makeTimeInterval(params().Interval()) }
+   *     {
+   *       mf::LogInfo{ "MyAlgorithm" } << "Time interval: " << fInterval;
+   *     }
+   *   
+   *     private:
+   *   icarus::ns::util::TimeInterval<electronics_time> fInterval;
+   *   
+   * };
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * with a FHiCL configuration like:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * myalgorithm: {
+   *   Interval: { Start: "-5 us"  Duration: "+20 us" }
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    */
   template <typename Time>
   using TimeIntervalTable = ::fhicl::Table<TimeIntervalConfig<Time>> ;
@@ -79,7 +153,7 @@ namespace icarus::ns::fhicl {
    * This is a handy alias for a FHiCL configuration with an optional
    * `icarus::ns::fhicl::TimeIntervalConfig` entry.
    * Note that since FHiCL tables do not support default values, this is the
-   * way to have one (see `icarus::ns::fhicl::TimeIntervalConfig` example).
+   * way to have one.
    * 
    * Use it like in the FHiCL configuration object of an algorithm or module:
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
@@ -99,11 +173,69 @@ namespace icarus::ns::fhicl {
    *   
    * };
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * 
+   * It can be read for example in the constructor of a class (e.g. a module):
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * using namespace util::quantities::time_literals; // for `200_ns` etc.
+   * 
+   * class MyAlgorithm {
+   * 
+   *     public:
+   *   using nanosecond = util::quantities::points::nanosecond;
+   *   
+   *   struct Config {
+   *     
+   *     using Name = fhicl::Name;
+   *     using Comment = fhicl::Comment;
+   *     
+   *     icarus::ns::fhicl::TimeIntervalOptionalTable<nanosecond> Interval{
+   *       Name{ "Interval" },
+   *       Comment{ "override the selection time interval" }
+   *       };
+   *     
+   *   };
+   *   
+   *   using Parameters = fhicl::Table<Config>;
+   *   
+   *   MyAlgorithm(Parameters const& params)
+   *     : fInterval
+   *       {
+   *         icarus::ns::fhicl::makeTimeInterval(params().Interval())
+   *           .value_or(DefaultInterval)
+   *       }
+   *     {
+   *       mf::LogInfo{ "MyAlgorithm" } << "Time interval: " << fInterval;
+   *     }
+   *   
+   *     private:
+   *   icarus::ns::util::TimeInterval<nanosecond> fInterval;
+   *   
+   *   static constexpr icarus::ns::util::TimeInterval<nanosecond>
+   *     DefaultInterval{ -100_ns, +200_ns};
+   * };
+   * 
+   * inline constexpr icarus::ns::util::TimeInterval<util::quantities::points::nanosecond>
+   *   MyAlgorithm::DefaultInterval{ -100_ns, +200_ns};
+   * 
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * with a FHiCL configuration like:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * myalgorithm: {
+   *   Interval: { Start: "-5 us"  Duration: "+20 us" }
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * or it can be omitted altogether:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * myalgorithm: {
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * (_not_ the same as specifying `Interval: {}`, which will yield an empty
+   * `[ 0, 0 ]` interval).
    */
   template <typename Time>
   using TimeIntervalOptionalTable
     = ::fhicl::OptionalTable<TimeIntervalConfig<Time>>;
-    
+  
 } // namespace icarus::ns::fhicl
 
 
@@ -111,9 +243,26 @@ namespace icarus::ns::fhicl {
 /**
  * @brief FHiCL configuration object for specification of a (time) interval.
  * @tparam Time the type of the time point being read by the configuration
+ * @see `icarus::ns::fhicl::TimeIntervalTable`,
+ *      `icarus::ns::fhicl::TimeIntervalOptionalTable`
  * 
+ * See `icarus::ns::fhicl::TimeIntervalTable` and
+ * `icarus::ns::fhicl::TimeIntervalOptionalTable` for complete example usages.
  * 
+ * Examples of configuration:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * intervalA: {  Start: "-5 us"  Duration: "15 us"  }  # [ -5 ; +10 ] us
+ * intervalB: {  Start: "-5 us"  End: "10 us"  }       # [ -5 ; +10 ] us
+ * intervalC: {  Duration: "15 us"  End: "10 us"  }    # [ -5 ; +10 ] us
+ * intervalD: {  Duration: "200 ns"  }                 # [  0 ; +0.2 ] us
+ * intervalE: {  End: "200 ns"  }                      # [  0 ; +0.2 ] us
+ * intervalF: {  }                                     # [  0 ; 0 ]
  * 
+ * # this (valid FHiCL) would not parse with `makeTimeInterval()` helpers:
+ * # intervalG: {  Start: "-5 us"  Duration: "15 us"  End: "10 us"  }
+ * 
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 template <typename Time> 
 struct icarus::ns::fhicl::TimeIntervalConfig {

--- a/icarusalg/Utilities/sortBy.h
+++ b/icarusalg/Utilities/sortBy.h
@@ -16,7 +16,7 @@
 #include <functional> // std::less<>
 #include <vector>
 #include <iterator> // std::back_inserter()
-#include <utility> // std::pair>?
+#include <utility> // std::pair<>
 #include <type_traits> // std::is_base_of_v
 
 
@@ -30,7 +30,8 @@ namespace util {
    * @tparam EIter type of end iterator to objects to be sorted
    * @tparam Key type of functor extracting the key from an element
    * @tparam Sorter (default: `std::less`) type of functor comparing two keys
-   * @param coll collection of objects to be sorted
+   * @param begin iterator to the first element of the collection to be sorted
+   * @param end iterator after the last element of the collection to be sorted
    * @param key functor extracting the key from an element
    * @param sorter (default: `std::less{}`) functor comparing two keys
    * @return a vector of pointers to `coll` elements, sorted by `key`

--- a/icarusalg/Utilities/sortLike.h
+++ b/icarusalg/Utilities/sortLike.h
@@ -1,0 +1,247 @@
+/**
+ * @file   icarusalg/Utilities/sortLike.h
+ * @brief  Provides `sortLike()` class of utilities.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 28, 2023
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSALG_UTILITIES_SORTLIKE_H
+#define ICARUSALG_UTILITIES_SORTLIKE_H
+
+
+// C/C++ standard libraries
+#include <algorithm> // std::partition()
+#include <functional> // std::less<>
+#include <vector>
+#include <iterator> // std::back_inserter(), std::iterator_traits, ...
+#include <utility> // std::pair<>
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+namespace util {
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Sorts elements on a range according to keys from another range.
+   * @tparam BIter type of begin iterator to objects to be sorted
+   * @tparam EIter type of end iterator to objects to be sorted
+   * @tparam BKIter type of begin (constant) iterator to sorting keys
+   * @tparam EKIter type of end (constant) iterator to sorting keys
+   * @tparam Comp (default: `std::less`) type of functor comparing two keys
+   * @param begin iterator to the first element of the collection to be sorted
+   * @param end iterator after the last element of the collection to be sorted
+   * @param key_begin iterator to the sorting key of the first object
+   * @param key_end iterator to the sorting key after the last object
+   * @param comp (default: `std::less{}`) functor comparing two keys
+   * @see `sortCollLike()`
+   * 
+   * This function sorts the elements between `begin` and `end` using the
+   * respective entries between `key_begin` and `key_end` as sorting keys.
+   * Sorting happens in place (or it should look like it did).
+   * 
+   * The structure of the vector is not changed, so effectively the iterators
+   * are not invalidated.
+   * 
+   * Example:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::string name = "ACIRSU";
+   * constexpr std::array order{ 3, 2, 1, 4, 6, 5 };
+   * 
+   * util::sortLike(name.begin(), name.end(), order.begin(), order.end());
+   * std::cout << name << std::endl;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * should print `ICARUS`.
+   * 
+   * Requirements
+   * =============
+   * 
+   * The requirements are pretty much the same as for `std::sort()`:
+   *  * the objects contained in `Data` must be swappable.
+   * 
+   * In fact, chances are that the requirements are looser, since the algorithm
+   * should work also with any forward iterator.
+   */
+  template <
+    typename BIter, typename EIter, typename BKIter, typename EKIter,
+    typename Comp = std::less<void>
+    >
+  void sortLike
+    (BIter begin, EIter end, BKIter key_begin, EKIter key_end, Comp comp = {});
+
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Sorts `data` elements according to keys from another range.
+   * @tparam DataColl type of collection of objects to be sorted
+   * @tparam KeyColl type of collection with sorting keys
+   * @tparam Comp (default: `std::less`) type of functor comparing two keys
+   * @param data collection of objects to be sorted
+   * @param keys collection of the sorting keys for `data`
+   * @param comp (default: `std::less{}`) functor comparing two keys
+   * @see `sortLike()`
+   * 
+   * Sorting happens in place (or it should look like it did).
+   * 
+   * Example:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::string name = "ACIRSU";
+   * constexpr std::array order{ 3, 2, 1, 4, 6, 5 };
+   * 
+   * util::sortCollLike(name, order);
+   * std::cout << name << std::endl;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * should print `ICARUS`.
+   * 
+   */
+  template <typename DataColl, typename KeyColl, typename Comp = std::less<>>
+  void sortCollLike(DataColl& data, KeyColl const& keys, Comp comp = {});
+  
+  // ---------------------------------------------------------------------------
+  
+} // namespace util
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+namespace util::details {
+  
+  /// Special type to allow `swap()` customization.
+  template <typename FirstIter, typename SecondIter>
+  struct SwappableIteratorPair {
+    using This_t = SwappableIteratorPair<FirstIter, SecondIter>;
+    
+    FirstIter first;
+    SecondIter second;
+    
+    bool operator< (This_t const& other) const noexcept
+      { return *first < *(other.first); }
+    friend void swap(This_t& a, This_t& b) noexcept
+      {
+        using std::swap;
+        swap(a.first, b.first);
+        std::iter_swap(a.second, b.second);
+      }
+  }; // struct SwappableIteratorPair
+  
+  
+  // Shamelessly copied on 2023-08-13 from example in
+  // https://en.cppreference.com/w/cpp/algorithm/partition;
+  // because, seriously: who wants to write quick sort from scratch again??
+  // this sorting algorithm us not stable and requires the value to be copyable
+  template<typename FwdIter, typename Comp = std::less<>>
+  void unoptimisedQuickSort(FwdIter begin, FwdIter end, Comp const& comp = {}) {
+    if (begin == end) return;
+    
+    using PtrDiff_t = typename std::iterator_traits<FwdIter>::difference_type;
+    using Value_t = typename std::iterator_traits<FwdIter>::value_type;
+    
+    // we could branch out with an optimization for small collections here
+    PtrDiff_t const size = std::distance(begin, end);
+    
+    // std::partition() will move the pivot value around, so we can't just refer
+    // to it, we really need a copy (or to track its moves)
+    Value_t const pivot = *std::next(begin, size / 2); // copy happens here
+    FwdIter const middle1 = std::partition(
+      begin, end, [&pivot,&comp](Value_t const& v){ return comp(v, pivot); }
+      );
+    // [ middle1; middle2 [ all have the same value
+    FwdIter const middle2 = std::partition(
+      middle1, end, [&pivot,&comp](Value_t const& v){ return !comp(pivot, v); }
+      );
+
+    unoptimisedQuickSort(begin, middle1, comp);
+    unoptimisedQuickSort(middle2, end, comp);
+  } // unoptimisedQuickSort()
+
+} // namespace util::details
+
+
+// -----------------------------------------------------------------------------
+template <
+  typename BIter, typename EIter, typename BKIter, typename EKIter,
+  typename Comp /* = std::less<void> */
+  >
+void util::sortLike(
+  BIter begin, EIter end, BKIter key_begin, EKIter key_end, Comp comp /* = {} */
+) {
+#if 1
+  
+  /*
+   * make the container of references (to be sorted);
+   * the type SwappableIteratorPair is special in that when swapped
+   * the iterators to the keys get swapped (unusual, to allow them constant)
+   * while the iterators to data are left as they are, but data is swapped
+   *   instead (as usual, to avoid memory allocation).
+   * A side effect of actually sorting a `std::vector` is that its iterators
+   * are random iterators and provide the random access functionality to the
+   * underlying iterators (which probably can just be forward iterators).
+   * 
+   * Unfortunately `std::sort()` in GCC has an optimization where for small
+   * collections it will use a different algorithm which moves instead of
+   * swapping, and it turns out that making SwappableIteratorPair efficiently
+   * moveable is very hard. So I am backing up to a custom algorithm that always
+   * uses swaps.
+   */
+  using Ref_t = details::SwappableIteratorPair<BKIter, BIter>;
+  std::vector<Ref_t> dataKeyRef;
+  while (key_begin != key_end) dataKeyRef.push_back({ key_begin++, begin++ });
+  assert(begin == end);
+  
+  // sort it
+  struct RefComparer {
+    Comp comp;
+    bool operator() (Ref_t const& a, Ref_t const& b) const
+      { return comp(*(a.first), *(b.first)); }
+  };
+  details::unoptimisedQuickSort
+    (dataKeyRef.begin(), dataKeyRef.end(), RefComparer{ std::move(comp) });
+  
+#else // this is a more standard (and slower) implementation:
+  
+  // move the content of `data` and copy a `keys` iterator into a new vector
+  // of pairs
+  using Ref_t
+    = std::pair<BKIter, typename std::iterator_traits<BIter>::value_type>;
+  std::vector<Ref_t> dataKeyRef;
+  auto itData = begin, itKey = key_begin;
+  while (itKey != key_end)
+    dataKeyRef.emplace_back(itKey++, std::move(*itData++));
+  assert(itData == end);
+  
+  // sort it
+  struct RefComparer {
+    Comp comp;
+    bool operator() (Ref_t const& a, Ref_t const& b)
+      { return comp(*(a.first), *(b.first)); }
+  };
+  std::sort
+    (dataKeyRef.begin(), dataKeyRef.end(), RefComparer{ std::move(comp) });
+  
+  // move back into `data`
+  itData = begin;
+  for (Ref_t& keyAndData: dataKeyRef) *itData++ = std::move(keyAndData.second);
+  
+#endif // 0
+  
+} // util::sortLike()
+
+
+// -----------------------------------------------------------------------------
+template
+  <typename DataColl, typename KeyColl, typename Comp /* = std::less<> */>
+void util::sortCollLike
+  (DataColl& data, KeyColl const& keys, Comp comp /* = {} */)
+{
+  using std::begin, std::end;
+  sortLike(begin(data), end(data), begin(keys), end(keys), std::move(comp));
+} // util::sortCollLike()
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSALG_UTILITIES_SORTLIKE_H

--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -20,7 +20,7 @@ cet_test(IntegerRanges_test LIBRARIES cetlib::cetlib larcorealg::CoreUtils USE_B
 
 cet_test(BinningSpecs_test
   LIBRARIES
-    icarusalg_Utilities
+    icarusalg::Utilities
     cetlib::cetlib
   USE_BOOST_UNIT
   )
@@ -43,6 +43,13 @@ cet_test(TrackTimeInterval_test USE_BOOST_UNIT
   larcorealg::geometry_unit_test_base
   larcorealg::Geometry
   lardataobj::RecoBase
+)
+
+cet_test(TimeIntervalConfig_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+    icarusalg::Utilities
+    lardataalg::DetectorInfo
+    fhiclcpp::fhiclcpp
 )
 
 cet_test(AssnsCrosser_test

--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -61,3 +61,8 @@ cet_test(AssnsCrosser_test
   USE_BOOST_UNIT
   )
 
+cet_test(sortLike_test
+  LIBRARIES
+    icarusalg::Utilities
+  USE_BOOST_UNIT
+  )

--- a/test/Utilities/TimeIntervalConfig_test.cc
+++ b/test/Utilities/TimeIntervalConfig_test.cc
@@ -1,0 +1,363 @@
+/**
+ * @file   TimeIntervalConfig_test.cc
+ * @brief  Unit test for `icarus::ns::fhicl::TimeIntervalConfig`.
+ * @date   August 18, 2023
+ * @author petrillo@slac.stanford.edu
+ *
+ * Usage: just run the executable.
+ */
+
+// Boost test libraries; defining this symbol tells boost somehow to generate
+// a main() function
+#define BOOST_TEST_MODULE TimeIntervalConfigTest
+#include <cetlib/quiet_unit_test.hpp> // BOOST_AUTO_TEST_CASE()
+#include <boost/test/test_tools.hpp> // BOOST_TEST()
+
+// ICARUS libraries
+#include "icarusalg/Utilities/TimeIntervalConfig.h"
+
+// LArSoft libraries
+#include "lardataalg/Utilities/quantities/spacetime.h"
+#include "lardataalg/DetectorInfo/DetectorTimingTypes.h" // electronics_time
+
+// framework libraries
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/Table.h"
+#include "cetlib_except/exception.h"
+
+// C/C++ standard libraries
+#include <optional>
+
+
+// -----------------------------------------------------------------------------
+void TimeIntervalTable_doc2_test() {
+  /*
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * class MyAlgorithm {
+   * 
+   *     public:
+   *   
+   *   using electronics_time = detinfo::timescales::electronics_time;
+   *   
+   *   struct Config {
+   *     
+   *     using Name = fhicl::Name;
+   *     using Comment = fhicl::Comment;
+   *     
+   *     icarus::ns::fhicl::TimeIntervalTable<electronics_time> Interval{
+   *       Name{ "Interval" },
+   *       Comment{ "specify the selection time interval" }
+   *       };
+   *     
+   *   };
+   *   
+   *   using Parameters = fhicl::Table<Config>;
+   *   
+   *   MyAlgorithm(Parameters const& params)
+   *     : fInterval
+   *       { icarus::ns::fhicl::makeTimeInterval(params().Interval()) }
+   *     {
+   *       mf::LogInfo{ "MyAlgorithm" } << "Time interval: " << fInterval;
+   *     }
+   *   
+   *     private:
+   *   icarus::ns::util::TimeInterval<electronics_time> fInterval;
+   *   
+   * };
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * with a FHiCL configuration like:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * myalgorithm: {
+   *   Interval: { Start: "-5 us"  Duration: "+20 us" }
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  
+  class MyAlgorithm {
+  
+      public:
+    
+    using electronics_time = detinfo::timescales::electronics_time;
+    
+    struct Config {
+      
+      using Name = fhicl::Name;
+      using Comment = fhicl::Comment;
+      
+      icarus::ns::fhicl::TimeIntervalTable<electronics_time> Interval{
+        Name{ "Interval" },
+        Comment{ "specify the selection time interval" }
+        };
+      
+    };
+    
+    using Parameters = fhicl::Table<Config>;
+    
+    MyAlgorithm(Parameters const& params)
+      : fInterval
+        { icarus::ns::fhicl::makeTimeInterval(params().Interval()) }
+      {
+        mf::LogInfo{ "MyAlgorithm" } << "Time interval: " << fInterval;
+      }
+    
+      private:
+    icarus::ns::util::TimeInterval<electronics_time> fInterval;
+    
+      public:
+    icarus::ns::util::TimeInterval<electronics_time> const& interval() const
+      { return fInterval; }
+    
+  };
+  
+  auto const config = fhicl::ParameterSet::make(R"(
+myalgorithm: {
+  Interval: { Start: "-5 us"  Duration: "+20 us" }
+}
+)");
+
+  // ---------------------------------------------------------------------------
+  using namespace util::quantities::time_literals;
+
+  MyAlgorithm const testAlg{ config.get<fhicl::ParameterSet>("myalgorithm") };
+  
+  auto const& interval = testAlg.interval();
+  BOOST_TEST(interval.start.value() == -5.0);
+  BOOST_TEST(interval.stop.value() == +15.0);
+  
+} // TimeIntervalTable_doc2_test()
+
+
+// -----------------------------------------------------------------------------
+void TimeIntervalOptionalTable_doc2_test() {
+  /*
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * using namespace util::quantities::time_literals; // for `200_ns` etc.
+   * 
+   * class MyAlgorithm {
+   * 
+   *     public:
+   *   using nanosecond = util::quantities::points::nanosecond;
+   *   
+   *   struct Config {
+   *     
+   *     using Name = fhicl::Name;
+   *     using Comment = fhicl::Comment;
+   *     
+   *     icarus::ns::fhicl::TimeIntervalOptionalTable<nanosecond> Interval{
+   *       Name{ "Interval" },
+   *       Comment{ "override the selection time interval" }
+   *       };
+   *     
+   *   };
+   *   
+   *   using Parameters = fhicl::Table<Config>;
+   *   
+   *   MyAlgorithm(Parameters const& params)
+   *     : fInterval
+   *       {
+   *         icarus::ns::fhicl::makeTimeInterval(params().Interval())
+   *           .value_or(DefaultInterval)
+   *       }
+   *     {
+   *       mf::LogInfo{ "MyAlgorithm" } << "Time interval: " << fInterval;
+   *     }
+   *   
+   *     private:
+   *   icarus::ns::util::TimeInterval<nanosecond> fInterval;
+   *   
+   *   static constexpr icarus::ns::util::TimeInterval<nanosecond>
+   *     DefaultInterval{ -100_ns, +200_ns};
+   * };
+   * 
+   * inline constexpr icarus::ns::util::TimeInterval<util::quantities::points::nanosecond>
+   *   MyAlgorithm::DefaultInterval{ -100_ns, +200_ns};
+   * 
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * with a FHiCL configuration like:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * myalgorithm: {
+   *   Interval: { Start: "-5 us"  Duration: "+20 us" }
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * or it can be omitted altogether:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * myalgorithm: {
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * (_not_ the same as specifying `Interval: {}`, which will yield an empty
+   * `[ 0, 0 ]` interval).
+   */
+  
+  using namespace util::quantities::time_literals; // for `200_ns` etc.
+  
+  static constexpr
+  icarus::ns::util::TimeInterval<util::quantities::points::nanosecond>
+    DefaultInterval{ -100_ns, +200_ns};
+  
+  class MyAlgorithm {
+  
+      public:
+    using nanosecond = util::quantities::points::nanosecond;
+    
+    struct Config {
+      
+      using Name = fhicl::Name;
+      using Comment = fhicl::Comment;
+      
+      icarus::ns::fhicl::TimeIntervalOptionalTable<nanosecond> Interval{
+        Name{ "Interval" },
+        Comment{ "override the selection time interval" }
+        };
+      
+    };
+    
+    using Parameters = fhicl::Table<Config>;
+    
+    MyAlgorithm(Parameters const& params)
+      : fInterval
+        {
+          icarus::ns::fhicl::makeTimeInterval(params().Interval())
+            .value_or(DefaultInterval)
+        }
+      {
+         mf::LogInfo{ "MyAlgorithm" }
+           << "Time interval: " << fInterval;
+      }
+    
+      private:
+    icarus::ns::util::TimeInterval<nanosecond> fInterval;
+    
+      public:
+    icarus::ns::util::TimeInterval<nanosecond> const& interval() const
+      { return fInterval; }
+    
+  };
+  
+  // inline constexpr icarus::ns::util::TimeInterval<util::quantities::points::nanosecond>
+  // MyAlgorithm::DefaultInterval;
+
+  auto const config1 = fhicl::ParameterSet::make(R"(
+myalgorithm: {
+  Interval: { Start: "-5 us"  Duration: "+20 us" }
+}
+)");
+  
+  auto const config2 = fhicl::ParameterSet::make(R"(
+myalgorithm: {
+}
+)");
+  
+  // ---------------------------------------------------------------------------
+  MyAlgorithm const testAlg1
+    { config1.get<fhicl::ParameterSet>("myalgorithm") };
+  
+  auto const& interval1 = testAlg1.interval();
+  BOOST_TEST(interval1.start.value() ==  -5'000.0);
+  BOOST_TEST(interval1.stop.value()  == +15'000.0);
+  
+  MyAlgorithm const testAlg2
+    { config2.get<fhicl::ParameterSet>("myalgorithm") };
+  
+  auto const& interval2 = testAlg2.interval();
+  BOOST_TEST(interval2.start.value() == -100.0);
+  BOOST_TEST(interval2.stop.value()  == +200.0);
+  
+} // TimeIntervalOptionalTable_doc2_test()
+
+
+// -----------------------------------------------------------------------------
+void TimeIntervalConfig_doc_test() {
+  /*
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * intervalA: {  Start: "-5 us"  Duration: "15 us"  }  # [ -5 ; +10 ] us
+   * intervalB: {  Start: "-5 us"  End: "10 us"  }       # [ -5 ; +10 ] us
+   * intervalC: {  Duration: "15 us"  End: "10 us"  }    # [ -5 ; +10 ] us
+   * intervalD: {  Duration: "200 ns"  }                 # [  0 ; +0.2 ] us
+   * intervalE: {  End: "200 ns"  }                      # [  0 ; +0.2 ] us
+   * intervalF: {  }                                     # [  0 ; 0 ]
+   * 
+   * # this (valid FHiCL) would not parse with `makeTimeInterval()` helpers:
+   * # intervalG: {  Start: "-5 us"  Duration: "15 us"  End: "10 us"  }
+   * 
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  
+  auto const config = fhicl::ParameterSet::make(R"(
+intervalA: {  Start: "-5 us"  Duration: "15 us"  }  # [ -5 ; +10 ] us
+intervalB: {  Start: "-5 us"  End: "10 us"  }       # [ -5 ; +10 ] us
+intervalC: {  Duration: "15 us"  End: "10 us"  }    # [ -5 ; +10 ] us
+intervalD: {  Duration: "200 ns"  }                 # [  0 ; +0.2 ] us
+intervalE: {  End: "200 ns"  }                      # [  0 ; +0.2 ] us
+intervalF: {  }                                     # [  0 ; 0 ]
+
+# this (valid FHiCL) would not parse with `makeTimeInterval()` helpers:
+intervalG: {  Start: "-5 us"  Duration: "15 us"  End: "10 us"  }
+)");
+  
+  // ---------------------------------------------------------------------------
+  using microsecond = util::quantities::points::microsecond;
+  icarus::ns::util::TimeInterval<microsecond> interval;
+
+  std::optional<fhicl::Table<icarus::ns::fhicl::TimeIntervalConfig<microsecond>>>
+  configTable;
+
+  configTable.emplace(config.get<fhicl::ParameterSet>("intervalA"));
+  interval = makeTimeInterval((*configTable)());
+  BOOST_TEST(interval.start.value() ==  -5.0);
+  BOOST_TEST(interval.stop.value()  == +10.0);
+  
+  configTable.emplace(config.get<fhicl::ParameterSet>("intervalB"));
+  interval = makeTimeInterval((*configTable)());
+  BOOST_TEST(interval.start.value() ==  -5.0);
+  BOOST_TEST(interval.stop.value()  == +10.0);
+  
+  configTable.emplace(config.get<fhicl::ParameterSet>("intervalC"));
+  interval = makeTimeInterval((*configTable)());
+  BOOST_TEST(interval.start.value() ==  -5.0);
+  BOOST_TEST(interval.stop.value()  == +10.0);
+  
+  configTable.emplace(config.get<fhicl::ParameterSet>("intervalD"));
+  interval = makeTimeInterval((*configTable)());
+  BOOST_TEST(interval.start.value() == 0.0);
+  BOOST_TEST(interval.stop.value()  == 0.2);
+  
+  configTable.emplace(config.get<fhicl::ParameterSet>("intervalE"));
+  interval = makeTimeInterval((*configTable)());
+  BOOST_TEST(interval.start.value() == 0.0);
+  BOOST_TEST(interval.stop.value()  == 0.2);
+  
+  configTable.emplace(config.get<fhicl::ParameterSet>("intervalF"));
+  interval = makeTimeInterval((*configTable)());
+  BOOST_TEST(interval.start.value() == 0.0);
+  BOOST_TEST(interval.stop.value()  == 0.0);
+  
+  configTable.emplace(config.get<fhicl::ParameterSet>("intervalG"));
+  icarus::ns::fhicl::TimeIntervalConfig const intervalConfig = (*configTable)();
+  BOOST_CHECK_THROW(makeTimeInterval(intervalConfig), cet::exception);
+  
+} // TimeIntervalConfig_doc_test()
+
+
+// -----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(TimeIntervalTable_tests) {
+  
+  TimeIntervalTable_doc2_test();
+  
+} // BOOST_AUTO_TEST_CASE(TimeIntervalTable_tests)
+
+BOOST_AUTO_TEST_CASE(TimeIntervalOptionalTable_tests) {
+  
+  TimeIntervalOptionalTable_doc2_test();
+  
+} // BOOST_AUTO_TEST_CASE(TimeIntervalOptionalTable_tests)
+
+
+BOOST_AUTO_TEST_CASE(TimeIntervalConfig_tests) {
+  
+  TimeIntervalConfig_doc_test();
+  
+} // BOOST_AUTO_TEST_CASE(TimeIntervalConfig_tests)
+
+
+// -----------------------------------------------------------------------------

--- a/test/Utilities/sortLike_test.cc
+++ b/test/Utilities/sortLike_test.cc
@@ -1,0 +1,213 @@
+/**
+ * @file   sortLike_test.cc
+ * @brief  Unit test for utilities from `sortLike.h`.
+ * @date   August 28, 2022
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    `icarusalg/Utilities/sortLike.h`
+ */
+
+// Boost libraries
+#define BOOST_TEST_MODULE sortLike
+#include <boost/test/unit_test.hpp>
+#include <boost/iterator/transform_iterator.hpp>
+
+// ICARUS libraries
+#include "icarusalg/Utilities/sortLike.h"
+
+// C/C++ standard library
+#include <ostream>
+#include <algorithm> // std::sort()
+#include <functional> // std::greater<>
+#include <memory> // std::unique_ptr()
+#include <string>
+#include <array>
+#include <vector>
+
+
+//------------------------------------------------------------------------------
+class NastyUncopiableData {
+  
+  std::unique_ptr<int> fValue;
+  
+    public:
+  
+  NastyUncopiableData(int value): fValue{ std::make_unique<int>(value) } {}
+  
+  bool hasValue() const noexcept { return bool(fValue); }
+  int value() const noexcept { return *fValue; }
+  
+  operator int() const noexcept { return value(); }
+  
+  bool operator< (NastyUncopiableData const& other) const noexcept
+    {
+      if (hasValue()) {
+        return other.hasValue()? (value() < other.value()): false;
+      }
+      else return !other.hasValue();
+    }
+  
+}; // NastyUncopiableData
+
+std::ostream& operator<< (std::ostream& out, NastyUncopiableData const& data) {
+  if (data.hasValue()) out << "<" << data.value() << ">";
+  else out << "<n/a>";
+  return out;
+}
+
+
+//------------------------------------------------------------------------------
+void sortLike_test1() {
+  
+  std::vector const values{
+     8,  6,  4,  2,  7,  5,  3,
+    28, 26, 24, 22, 27, 25, 23,
+    18, 16, 14, 12, 17, 15, 13,
+    };
+  
+  std::vector<NastyUncopiableData> data;
+  for (int v: values) data.emplace_back(v);
+  
+  auto const dbegin = data.begin(), dend = data.end();
+  
+  auto extractKeys = [](auto const& values)
+    {
+      std::vector<float> keys;
+      for (int const v: values) keys.push_back(-float(v));
+      return keys;
+    };
+  std::vector<float> const keys = extractKeys(values);
+
+  std::vector<int> expectedData{ values };
+  std::sort(expectedData.begin(), expectedData.end(), std::greater<>{});
+  
+  util::sortLike(data.begin(), data.end(), keys.begin(), keys.end());
+  
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    boost::transform_iterator
+      (data.begin(), std::mem_fn(&NastyUncopiableData::value)),
+    boost::transform_iterator
+      (data.end(), std::mem_fn(&NastyUncopiableData::value)),
+    expectedData.cbegin(), expectedData.cend()
+    );
+  
+  // iterators should not be invalidated
+  BOOST_TEST((data.begin() == dbegin));
+  BOOST_TEST((data.end() == dend));
+  
+} // sortLike_test1()
+
+
+//------------------------------------------------------------------------------
+void sortLike_doc1_test() {
+  /*
+   * The promise:
+   */
+  /*
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::string name = "ACIRSU";
+   * constexpr std::array order{ 3, 2, 1, 4, 6, 5 };
+   * 
+   * util::sortLike(name.begin(), name.end(), order.begin(), order.end());
+   * std::cout << name << std::endl;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * should print `ICARUS`.
+   */
+  
+  std::string name = "ACIRSU";
+  constexpr std::array order{ 3, 2, 1, 4, 6, 5 };
+  
+  util::sortLike(name.begin(), name.end(), order.begin(), order.end());
+  
+  BOOST_TEST(name == "ICARUS");
+  
+} // sortLike_doc1_test()
+
+
+//------------------------------------------------------------------------------
+void sortCollLike_test1() {
+  
+  std::vector const values{
+     8,  6,  4,  2,  7,  5,  3,
+    28, 26, 24, 22, 27, 25, 23,
+    18, 16, 14, 12, 17, 15, 13,
+    };
+  
+  std::vector<NastyUncopiableData> data;
+  for (int v: values) data.emplace_back(v);
+  
+  auto const dbegin = data.begin(), dend = data.end();
+  
+  auto extractKeys = [](auto const& values)
+    {
+      std::vector<float> keys;
+      for (int const v: values) keys.push_back(-float(v));
+      return keys;
+    };
+  std::vector<float> const keys = extractKeys(values);
+
+  std::vector<int> expectedData{ values };
+  std::sort(expectedData.begin(), expectedData.end(), std::greater<>{});
+  
+  util::sortCollLike(data, keys);
+  
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    boost::transform_iterator
+      (data.begin(), std::mem_fn(&NastyUncopiableData::value)),
+    boost::transform_iterator
+      (data.end(), std::mem_fn(&NastyUncopiableData::value)),
+    expectedData.cbegin(), expectedData.cend()
+    );
+  
+  // iterators should not be invalidated
+  BOOST_TEST((data.begin() == dbegin));
+  BOOST_TEST((data.end() == dend));
+  
+} // sortCollLike_test1()
+
+
+//------------------------------------------------------------------------------
+void sortCollLike_doc1_test() {
+  /*
+   * The promise:
+   */
+  /*
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::string name = "ACIRSU";
+   * constexpr std::array order{ 3, 2, 1, 4, 6, 5 };
+   * 
+   * util::sortLike(name.begin(), name.end(), order.begin(), order.end());
+   * std::cout << name << std::endl;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * should print `ICARUS`.
+   */
+  
+  std::string name = "ACIRSU";
+  constexpr std::array order{ 3, 2, 1, 4, 6, 5 };
+  
+  util::sortCollLike(name, order);
+  
+  BOOST_TEST(name == "ICARUS");
+  
+} // sortCollLike_doc1_test()
+
+
+//------------------------------------------------------------------------------
+//---  The tests
+//---
+BOOST_AUTO_TEST_CASE( sortLike_testcase ) {
+  
+  sortLike_test1();
+  
+  sortLike_doc1_test();
+  
+} // BOOST_AUTO_TEST_CASE( sortLike_testcase )
+
+BOOST_AUTO_TEST_CASE( sortCollLike_testcase ) {
+  
+  sortCollLike_test1();
+  
+  sortCollLike_doc1_test();
+  
+} // BOOST_AUTO_TEST_CASE( sortCollLike_testcase )
+
+


### PR DESCRIPTION
This request is supporting SBNSoftware/icaruscode#631 that includes new algorithms and a few updates:

* `util::sortLike()` function to do "indirect" sorting, sorting one collection according to the order of values from another. An example of application is sorting hits by their calibrated charge: that charge can be stored in a different collection, and then the hits can be sorted using `sortLike()` or `sortCollLike()` using the charge collection as driving keys. Unit-tested.
* `util::GroupByIndex` returning groups of objects (via pointers) according to an "index" extracted from each object; example of application is grouping the PMT waveforms by their channel number. Not unit-tested.
* `MultiChoiceSelector` is a utility in `lardataalg` which connects the values of an enumerator type to string aliases, which is used to have more descriptive messages and configuration parameters. Here a few helper are introduced to simplify the use of that tool in FHiCL configuration. A "common selectors" file is introduced where the most standard enumerators can be collected, and one is set up as both example and tool used in trigger emulation.

When I don't know whom to set as reviewer, I use @SFBayLaser. But this is mostly low level algorithmic stuff, so there is not much to review apart from possibly their interface.
