### PR TITLE
shift southwest modules to avoid overlap with southeast

### DIFF
--- a/icarusalg/Geometry/gdml/gen_crt_frags.py
+++ b/icarusalg/Geometry/gdml/gen_crt_frags.py
@@ -802,7 +802,7 @@ def minosSouthTagger():
 
         dxwest =  0.5*(mModL-ZM+minosCutModLengthSouthwest[i]) + gap - crosstwomodule
         dy = -0.5*y+PADTagger+(i+0.5)*mModW + i*SIDECRTSHELFTHICK
-        dz = 0.5*z - 1.5*SIDECRTPOSTWIDTH - separatetwomodule
+        dz = 0.5*z - 1.5*SIDECRTPOSTWIDTH + separatetwomodule
         coords.append((dxwest,dy,dz,0)) #x,y,z,vert=false, west side
 
     global feb_id

--- a/icarusalg/Geometry/gdml/gen_crt_frags_refactored.py
+++ b/icarusalg/Geometry/gdml/gen_crt_frags_refactored.py
@@ -837,7 +837,7 @@ def minosSouthTagger():
 
         dxwest =  0.5*(mModL-ZM+minosCutModLengthSouthwest[i]) + gap - crosstwomodule
         dy = -0.5*y+PADTagger+(i+0.5)*mModW + i*SIDECRTSHELFTHICK
-        dz = 0.5*z - 1.5*SIDECRTPOSTWIDTH - separatetwomodule
+        dz = 0.5*z - 1.5*SIDECRTPOSTWIDTH + separatetwomodule
         coords.append((dxwest,dy,dz,0)) #x,y,z,vert=false, west side
 
     global feb_id

--- a/icarusalg/Geometry/gdml/icarus_refactored_nounderscore_20230918.gdml
+++ b/icarusalg/Geometry/gdml/icarus_refactored_nounderscore_20230918.gdml
@@ -73557,47 +73557,47 @@
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule134cut497South"/>
-				<position name="posvolAuxDetMINOSmodule134cut497South" unit="cm" x="238.285" y="-358.905" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule134cut497South" unit="cm" x="238.285" y="-358.905" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule134cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule135cut497South"/>
-				<position name="posvolAuxDetMINOSmodule135cut497South" unit="cm" x="238.285" y="-276.035" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule135cut497South" unit="cm" x="238.285" y="-276.035" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule135cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule136cut497South"/>
-				<position name="posvolAuxDetMINOSmodule136cut497South" unit="cm" x="238.285" y="-193.165" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule136cut497South" unit="cm" x="238.285" y="-193.165" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule136cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule137cut497South"/>
-				<position name="posvolAuxDetMINOSmodule137cut497South" unit="cm" x="238.285" y="-110.295" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule137cut497South" unit="cm" x="238.285" y="-110.295" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule137cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule138cut497South"/>
-				<position name="posvolAuxDetMINOSmodule138cut497South" unit="cm" x="238.285" y="-27.425" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule138cut497South" unit="cm" x="238.285" y="-27.425" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule138cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule139cut497South"/>
-				<position name="posvolAuxDetMINOSmodule139cut497South" unit="cm" x="238.285" y="55.445" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule139cut497South" unit="cm" x="238.285" y="55.445" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule139cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule140cut325South"/>
-				<position name="posvolAuxDetMINOSmodule140cut325South" unit="cm" x="151.925" y="138.315" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule140cut325South" unit="cm" x="151.925" y="138.315" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule140cut325South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule141cut325South"/>
-				<position name="posvolAuxDetMINOSmodule141cut325South" unit="cm" x="151.925" y="221.185" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule141cut325South" unit="cm" x="151.925" y="221.185" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule141cut325South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule142cut325South"/>
-				<position name="posvolAuxDetMINOSmodule142cut325South" unit="cm" x="151.925" y="304.055" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule142cut325South" unit="cm" x="151.925" y="304.055" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule142cut325South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 		</volume>

--- a/icarusalg/Geometry/gdml/icarus_refactored_nounderscore_20230918_nowires.gdml
+++ b/icarusalg/Geometry/gdml/icarus_refactored_nounderscore_20230918_nowires.gdml
@@ -17468,47 +17468,47 @@
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule134cut497South"/>
-				<position name="posvolAuxDetMINOSmodule134cut497South" unit="cm" x="238.285" y="-358.905" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule134cut497South" unit="cm" x="238.285" y="-358.905" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule134cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule135cut497South"/>
-				<position name="posvolAuxDetMINOSmodule135cut497South" unit="cm" x="238.285" y="-276.035" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule135cut497South" unit="cm" x="238.285" y="-276.035" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule135cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule136cut497South"/>
-				<position name="posvolAuxDetMINOSmodule136cut497South" unit="cm" x="238.285" y="-193.165" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule136cut497South" unit="cm" x="238.285" y="-193.165" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule136cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule137cut497South"/>
-				<position name="posvolAuxDetMINOSmodule137cut497South" unit="cm" x="238.285" y="-110.295" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule137cut497South" unit="cm" x="238.285" y="-110.295" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule137cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule138cut497South"/>
-				<position name="posvolAuxDetMINOSmodule138cut497South" unit="cm" x="238.285" y="-27.425" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule138cut497South" unit="cm" x="238.285" y="-27.425" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule138cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule139cut497South"/>
-				<position name="posvolAuxDetMINOSmodule139cut497South" unit="cm" x="238.285" y="55.445" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule139cut497South" unit="cm" x="238.285" y="55.445" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule139cut497South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule140cut325South"/>
-				<position name="posvolAuxDetMINOSmodule140cut325South" unit="cm" x="151.925" y="138.315" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule140cut325South" unit="cm" x="151.925" y="138.315" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule140cut325South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule141cut325South"/>
-				<position name="posvolAuxDetMINOSmodule141cut325South" unit="cm" x="151.925" y="221.185" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule141cut325South" unit="cm" x="151.925" y="221.185" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule141cut325South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 			<physvol>
 				<volumeref ref="volAuxDetMINOSmodule142cut325South"/>
-				<position name="posvolAuxDetMINOSmodule142cut325South" unit="cm" x="151.925" y="304.055" z="4.0905"/>
+				<position name="posvolAuxDetMINOSmodule142cut325South" unit="cm" x="151.925" y="304.055" z="5.2905"/>
 				<rotation name="rotplusvolAuxDetMINOSmodule142cut325South" unit="deg" x="0" y="90" z="0"/>
 			</physvol>
 		</volume>


### PR DESCRIPTION
This PR is the result of investigations of an exception thrown when using the new refactored G4. It looks like in the current geometry the southwest and southeast modules are strictly overlapping, causing issues when looking up the module based on the position. In this PR we shift the z position of the southwest modules, thus avoiding the overlap. Tests are being run to confirm that this fixes the exception.