### PR TITLE
Fixed geometry unit test configurations

### DIFF
--- a/fcl/utilities/test_geometry_icarus.fcl
+++ b/fcl/utilities/test_geometry_icarus.fcl
@@ -14,7 +14,7 @@ process_name: testGeo
 
 services: {
   
-  @table::icarus_geometry_services 
+  Geometry: @local::icarus_unit_test_geometry
   
   message: {
     destinations: {

--- a/fcl/utilities/test_geometry_icarus.fcl
+++ b/fcl/utilities/test_geometry_icarus.fcl
@@ -14,7 +14,8 @@ process_name: testGeo
 
 services: {
   
-  Geometry: @local::icarus_unit_test_geometry
+  @table::icarus_geometry_services
+  Geometry: @local::icarus_unit_test_geometry # special configuration also suitable for unit tests
   
   message: {
     destinations: {

--- a/fcl/utilities/test_geometry_iterators_icarus.fcl
+++ b/fcl/utilities/test_geometry_iterators_icarus.fcl
@@ -13,8 +13,9 @@
 process_name: testGeoIter
 
 services: {
- 
-  Geometry: @local::icarus_unit_test_geometry
+  
+  @table::icarus_geometry_services
+  Geometry: @local::icarus_unit_test_geometry # special configuration also suitable for unit tests
   
   message: {
     destinations: {

--- a/fcl/utilities/test_geometry_iterators_icarus.fcl
+++ b/fcl/utilities/test_geometry_iterators_icarus.fcl
@@ -14,7 +14,7 @@ process_name: testGeoIter
 
 services: {
  
-  @table::icarus_geometry_services 
+  Geometry: @local::icarus_unit_test_geometry
   
   message: {
     destinations: {

--- a/icarusalg/Geometry/geometry_icarus.fcl
+++ b/icarusalg/Geometry/geometry_icarus.fcl
@@ -38,6 +38,15 @@
 # to see which are the current defaults.
 #
 #
+# Configuration for unit tests
+# -----------------------------
+#
+# The "service" configuration `icarus_unit_test_geometry` includes a
+# configuration of ICARUS geometry suitable for tests that use the LArSoft unit
+# test service helpers. It should be loaded in place of `icarus_geometry` in the
+# `services.Geometry` configuration table.
+#
+#
 # Legacy options
 # ---------------
 # 
@@ -212,6 +221,23 @@ icarus_geometry: @local::icarus_geometry_services.Geometry
 icarus_geo:      @local::icarus_geometry # backward compatibility
 
 icarus_geometry_helper:  @local::icarus_geometry_services.ExptGeoHelperInterface
+
+#
+# Unit test configuration
+#
+# ICARUS has moved the configuration of the channel mapping out of
+# "SortingParameters", for obvious reasons; but the test framework that
+# this test uses assumes it will find it there.
+# Also, our channel mapper does not appreciate finding a tool type parameter
+# in its configuration.
+#
+# This configuration was written for unit test service utilities as found in
+# LArSoft v09_82_01.
+#
+
+icarus_unit_test_geometry: @local::icarus_geometry
+icarus_unit_test_geometry.SortingParameters: @local::icarus_unit_test_geometry.ChannelMapping
+icarus_unit_test_geometry.SortingParameters.tool_type: @erase
 
 
 ################################################################################


### PR DESCRIPTION
Unit tests suffered from a TPC channel mapping configuration problem. Only code using LArSoft unit test service utilities are affected; the affected code will have for example `geo::GeometryCore::Nchannels()` return the value `53248` instead of `55296` (won't include any "ghost" channel).

Unit tests and other programs using those utilities (in C++ _gallery_, ROOT macros etc.) in general need to provide a FHiCL configuration file which includes the `Geometry` service configuration. Once this branch is merged, that configuration should configure the geometry like in:
```
services.Geometry: @local::icarus_unit_test_geometry
```
(`#include "geometry_icarus.fcl"` is required).

This additional piece of configuration could be added to the standard configuration, but it would be spurious in there since it's not used by LArSoft's `Geometry` service, which obtains the correct configuration from the service `ExptGeoHelperInterface`. However, if the reviewers prefer, that spurious piece of configuration can probably be added without fatal consequences beside the confusion of having the same configuration in three different places, and not used in this one.
