### PR TITLE
Small updates and a bug fix

### DIFF
--- a/icarusalg/PMT/Algorithms/SharedWaveformBaseline.cxx
+++ b/icarusalg/PMT/Algorithms/SharedWaveformBaseline.cxx
@@ -207,6 +207,7 @@ auto opdet::SharedWaveformBaseline::operator()
       end = begin + fParams.nSample / 2;
        */
       
+      continue;
     } // if
     
     //

--- a/icarusalg/gallery/examples/PMTwaveforms/C++/DrawPMTwaveforms.cpp
+++ b/icarusalg/gallery/examples/PMTwaveforms/C++/DrawPMTwaveforms.cpp
@@ -426,6 +426,14 @@ class DrawPMTwaveforms {
         Name{ "Threshold" },
         Comment{ "LVDS discrimination threshold, in ADC counts" }
         };
+      fhicl::OptionalAtom<int> BoardChannel {
+        Name{ "BoardChannel" },
+        Comment{ "Channel within the readout board (unused)" }
+        };
+      fhicl::OptionalAtom<int> BoardNumber {
+        Name{ "BoardNumber" },
+        Comment{ "Readout board number (unused)" }
+        };
     }; // ReadoutSettings_t
     
     

--- a/icarusalg/gallery/examples/PMTwaveforms/C++/PMTconfigToSettings.py
+++ b/icarusalg/gallery/examples/PMTwaveforms/C++/PMTconfigToSettings.py
@@ -67,7 +67,7 @@ def entryToFHiCL(entry, params = {}):
   keys = params.get('keys', entry.keys())
   return (
       "{ "
-    + ", ".join(f"{key}: {entry[key]:{paddings.get(key, 0)}d}" for key in keys)
+    + "  ".join(f"{key}: {entry[key]:{paddings.get(key, 0)}d}" for key in keys)
     + " }"
     )
   
@@ -101,7 +101,7 @@ def formatData(settings, args):
     return (
       ((args.varName + " : ") if args.varName else "") + "[\n"
       + ",\n".join(("  " + entryToFHiCL(entry, params)) for entry in settings)
-      + f"] {('# ' + args.varName) if args.varName else ''}\n"
+      + f"\n] {('# ' + args.varName) if args.varName else ''}\n"
       )
   elif args.outputFormat == "Python":
     return (


### PR DESCRIPTION
This is a composite pull request that includes a few independent minor changes:
1. bug fix in `SharedWaveformBaseline`: the algorithm was intended to exclude from baseline computation the waveforms showing hints of signal, but it was not. This algorithm is not used in the standard reconstruction.
2. `BinaryDumpUtils.h` dumpers can use a custom set of digits to represent values; especially useful for flag masks, where a `01101` can become `-xx-x` or ` YY Y` and so on.
3. added skip and max event arguments to `galleryUtils.forEach()` Python utility. As described in the updated documentation (`help(galleryUtils.forEach)`), an event loop now can look like:
    ```.py
    for iEvent, event in enumerate(forEach(event, maxEvents=5)):
        ...
    ```
    to process only the first 5 events or even:
    ```.py
    for iEvent, event in enumerate(forEach(event, maxEvents=5, skipEvents=8), 8):
        ...
    ```
    to process events from `#8` to `#14` and have `iEvent` correctly mark their number as `8`, `9` etc.
4. minor detail changes to gallery utilities to draw PMT waveforms into ROOT canvases.

The priority for this is "parasitic", that is it's fine to wait until other requests to `icarusalg` arrive before merging this one too.

Reviewers... eh.
* maybe @SFBayLaser for the Python change... the other changes, I really don't know.