### PR TITLE
`SharedWaveformBaseline`: fix crash when no waveforms are signal-free

### DIFF
--- a/icarusalg/PMT/Algorithms/SharedWaveformBaseline.cxx
+++ b/icarusalg/PMT/Algorithms/SharedWaveformBaseline.cxx
@@ -217,7 +217,7 @@ auto opdet::SharedWaveformBaseline::operator()
     
   }
   else {
-    // backup: take the median of the maximum sample values on all waveforms
+    // backup: take the median of the medians of all waveforms
     mf::LogTrace{ fLogCategory }
       << "No waveform of channel " << waveforms.front()->ChannelNumber()
       << " qualified for baseline computation: falling back to use all of them";

--- a/icarusalg/PMT/Algorithms/SharedWaveformBaseline.h
+++ b/icarusalg/PMT/Algorithms/SharedWaveformBaseline.h
@@ -119,6 +119,10 @@ class opdet::SharedWaveformBaseline {
   std::pair<double, double> acceptanceRange
     (std::vector<raw::OpDetWaveform const*> const& waveforms) const;
   
+  /// Returns the median of the maxima of each waveform.
+  raw::ADC_Count_t maximaMedian
+    (std::vector<raw::OpDetWaveform const*> const& waveforms) const;
+  
 }; // opdet::SharedWaveformBaseline
 
 

--- a/icarusalg/PMT/Algorithms/SharedWaveformBaseline.h
+++ b/icarusalg/PMT/Algorithms/SharedWaveformBaseline.h
@@ -44,7 +44,11 @@ namespace opdet { class SharedWaveformBaseline; }
  * 5. all the samples in the first portion of the remaining waveforms are
  *    averaged to obtain the final estimation of the baseline; this last step
  *    should increase the resolution of the baseline beyond the median that was
- *    obtained at step 2.
+ *    obtained at step 2;
+ * 6. if no waveform passed the check on step 4, then the baseline is defined as
+ *    the median of the set of medians from each waveform, in an attempt to
+ *    suppress the contribution of outliers. In this case, the number of used
+ *    samples is conventionally returned to be `0`.
  * 
  * The parameters are specified at algorithm construction time and are contained
  * in the `Params_t` object.
@@ -119,8 +123,20 @@ class opdet::SharedWaveformBaseline {
   std::pair<double, double> acceptanceRange
     (std::vector<raw::OpDetWaveform const*> const& waveforms) const;
   
+  /// Returns the list of medians of all the specified `waveforms`.
+  std::vector<raw::ADC_Count_t> waveformMedians
+    (std::vector<raw::OpDetWaveform const*> const& waveforms) const;
+    
   /// Returns the median of the maxima of each waveform.
   raw::ADC_Count_t maximaMedian
+    (std::vector<raw::OpDetWaveform const*> const& waveforms) const;
+  
+  /// Returns the median of the medians of the specified `waveforms`.
+  raw::ADC_Count_t medianOfMedians
+    (std::vector<raw::OpDetWaveform const*> const& waveforms) const;
+  
+  /// Returns the maximum among the medians of the specified `waveforms`.
+  raw::ADC_Count_t maximumOfMedians
     (std::vector<raw::OpDetWaveform const*> const& waveforms) const;
   
 }; // opdet::SharedWaveformBaseline

--- a/icarusalg/PMT/Algorithms/SharedWaveformBaseline.h
+++ b/icarusalg/PMT/Algorithms/SharedWaveformBaseline.h
@@ -34,7 +34,7 @@ namespace opdet { class SharedWaveformBaseline; }
  * of the waveforms, as follows:
  * 
  * 1. the RMS of the first portion of each baseline is computed;
- * 2. the median of the samples on the same samples is also computed;
+ * 2. the median of the samples on the same portion of data is also computed;
  * 3. an acceptance range is constructed, using the median of the sample as the
  *    center and `nRMS` times the median of the RMS as maximum distance from
  *    that center in either direction;
@@ -113,6 +113,11 @@ class opdet::SharedWaveformBaseline {
   Params_t fParams; ///< Algorithm parameters.
   
   std::string fLogCategory; ///< Name of stream category for console messages.
+  
+  
+  /// Returns central value and radius for the accepted sample range.
+  std::pair<double, double> acceptanceRange
+    (std::vector<raw::OpDetWaveform const*> const& waveforms) const;
   
 }; // opdet::SharedWaveformBaseline
 


### PR DESCRIPTION
The `SharedWaveformBaseline` algorithm is run at `Stage0` to determine a baseline from all the PMT waveforms (this is the last change, since after `Stage0` the content of most of the waveforms is dropped).

This algorithm tries to be picky and to exclude waveforms which appear to have some signal in the region the baseline is going to be extracted from. As explained later, it is an extremely rare occurrence that no waveform in a channel is signal-free. In this case, the algorithm throws an exception:
```
    ---- StdException BEGIN
      An exception was thrown while processing module PMTWaveformBaselinesFromChannelData/pmtbaselines run: 11973 subRun: 1 event: 114516
      StatCollector<>::Average(): divide by 0
    ---- StdException END
```
This was first reported by @icaromx.

The proposed code uses a fall-back algorithm when there are no signal-free waveforms.
The fallback is not great, but after all it's a fallback: we take the maximum value of each waveform (assuming that the signal has negative polarity and that there is no significant undershoot after the signal), and take the median value among those.

Reviewers:
 * @mvicenzi who is informed on the algorithm, the context, the PMT, the DAQ and pretty much all the rest;
 * @SFBayLaser because he probably wants this fixed.


#### About the overestimation in the fall-back algorithm

The fallback algorithm will definitely overestimate the baseline (value higher than it should). There are possible mitigations to this as well: for example, we do have a (questionable) baseline RMS value, so we could subtract a number of RMS based on the statistics related to the maximum (e.g. if we have 9,997 samples and they are equally spaced in the cumulative distribution of a normal curve, the maximum value is 3 standard deviations above the mean, so we can subtract 3 RMS from it and call it a baseline).

In the end, I don't think the case is common enough to warrant more care than the one in this fix.


#### About the likelihood of this issue being triggered

Because of how the readout of ICARUS PMT is designed, the pre-trigger time of all waveforms is almost always signal-free; this does not hold for the waveforms acquired on the beam gate, though. In some very rare cases, there is no waveform acquired outside the beam gate, and for some channels it may happen that there is signal at the very beginning of the beam gate. I thought this case to be exceedingly rare, which is true, but I did not appreciate that when it happens my code ([`StatsCollector::Average()`](https://code-doc.larsoft.org/docs/latest/html/classlar_1_1util_1_1StatCollector.html#a799c5d81b7e11cc9fcc243ce1f5f625a), specifically) throws an exception rather than returning a `nan`.