### PR TITLE
Fixes from Clang compilation errors

### DIFF
--- a/icarusalg/Utilities/BinaryDumpUtils.h
+++ b/icarusalg/Utilities/BinaryDumpUtils.h
@@ -516,7 +516,7 @@ constexpr auto icarus::ns::util::bin(T value)
 template
   <unsigned int const Bits, const char* Digits /* = DIGITS */, typename T>
 constexpr auto icarus::ns::util::bin(T value)
-  -> details::BinObj<T, sizeof(T)*8, Digits>
+  -> details::BinObj<T, Bits, Digits>
   { return details::BinObj<T, Bits, Digits>{ std::move(value) }; }
 
 

--- a/test/Utilities/NonRandomCounter_test.cc
+++ b/test/Utilities/NonRandomCounter_test.cc
@@ -13,6 +13,9 @@
 // ICARUS libraries
 #include "icarusalg/Utilities/NonRandomCounter.h"
 
+// C++ standard libraries
+#include <array>
+
 
 //------------------------------------------------------------------------------
 void Test() {


### PR DESCRIPTION
Clang 14 (`c14:prof`) complains about a couple of lines of code.
It is right.
The fixes are simple and technical.

Reviewers: who is the Collaboration C++ expert?