### PR TITLE
Accompanying sbnalg dependency update for icaruscode PR 852

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -250,7 +250,7 @@ gdmldir	product_dir	gdml
 ####################################
 product		version		qual	flags		<table_format=2>
 guideline_sl	v4_0_0		-
-sbnalg          v10_06_00_03	-
+sbnalg          v10_06_00_04	-
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION
[Icaruscode PR 85](https://github.com/SBNSoftware/icaruscode/pull/852) Adds G4 reinteraction weights to the cafmaker, but in doing so it moves from `sbncode v10_06_00_04` to `v10_06_00_05`, which consequently requires an updated `sbnalg` dependency here from `v10_06_00_03` to `v10_06_00_04`. 