### PR TITLE
Added support for channel status service in ICARUS Python interface [2/2]

### DIFF
--- a/icarusalg/gallery/helpers/python/ICARUSservices.py
+++ b/icarusalg/gallery/helpers/python/ICARUSservices.py
@@ -92,7 +92,9 @@ class ICARUSserviceManagerClass(LArSoftUtils.ServiceManagerInstance):
     `configPath` is included directly, and it is assumed that it already
     properly defines a `services` table.
     """
-    return DefaultConfigPath, DefaultServiceTable
+    return LArSoftUtils.ServiceManagerInstance.ConfigurationInfo(
+      configPath=self.DefaultConfigPath, serviceTable=self.DefaultServiceTable,
+      )
   # defaultConfiguration()
 
   def __init__(self):

--- a/icarusalg/gallery/helpers/python/ICARUSservices.py
+++ b/icarusalg/gallery/helpers/python/ICARUSservices.py
@@ -61,6 +61,20 @@ class ICARUSserviceManagerClass(LArSoftUtils.ServiceManagerInstance):
   DefaultConfigPath = "services_basic_icarus.fcl"
   DefaultServiceTable = "icarus_basic_services"
 
+  ICARUSextraServices = {
+
+    # NOTE: this requires LArSoft dependencies (`larevt`, `icaruscode`)
+    # and a more advanced configuration (e.g. `services_common_icarus.fcl`)
+    'ChannelStatusService': LArSoftUtils.SimpleServiceLoader(
+      "lariov::SIOVChannelStatusProvider",
+      configKey=".ChannelStatusProvider",
+      interfaceClass="lariov::ChannelStatusProvider",
+      headers = "larevt/CalibrationDBI/Providers/SIOVChannelStatusProvider.h",
+      libraries = "larevt_CalibrationDBI_Providers",
+      ),
+
+  } # ICARUSextraServices
+
   def defaultConfiguration(self):
     """
 
@@ -89,6 +103,16 @@ class ICARUSserviceManagerClass(LArSoftUtils.ServiceManagerInstance):
       )
   # __init__()
 
+  def serviceLoaderTable(self):
+    """Returns the table with the services with known loaders.
+    
+    This overrides the base class function (but it invokes it first anyway).
+    """
+    serviceLoaderTable = super().serviceLoaderTable()
+    serviceLoaderTable.update(self.ICARUSextraServices)
+    return serviceLoaderTable
+  # serviceLoaderTable()
+  
   def setup(self):
     """Prepares for ICARUS service provider access in python/Gallery."""
 


### PR DESCRIPTION
A new preset is introduced in `ICARUSserviceManagerClass` to streamline the initialisation of `ChannelStatus` service provider.
Note that there is nothing special of ICARUS for this, and if SBND uses the same service provider ([`lariov::SIOVChannelStatusProvider`](https://code-doc.larsoft.org/docs/latest/html/classlariov_1_1SIOVChannelStatusProvider.html)) the same pattern can be used in there too.

It uses extensions to the Python infrastructure for LArSoft in `sbnalg`, which are subject of PR SBNSoftware/sbnalg#7.

Reviewers:
 * @SFBayLaser as a power user
 * @marcodeltutto as expert of Python interface in SBN
 * copilot, just for curiosity
  
  This PR was "built" against `v10_06_00_01`. Since it's Python, there is no actual build though.


Usage
------

For this to work, software from the full LArSoft setup is needed (at least `larevt`, since `ChannelStatusProvider` lives there) and a configuration for that service, for example from `icaruscode`. So this feature is not self-contained in `icarusalg`.
One suitable configuration is currently `icarus_wirecalibration_minimum_services` table from `services_common_icarus.fcl`.
With that,
```py
chanStatus = ICARUSservices.ServiceManager.get("ChannelStatusService")
```
should "just work" in constructing and initialising a channel status service provider.
Remember that in order to use that service one has also to call `chanStatus.Update(ts)` with the appropriate timestamp, which is apparently in the form `s * 1_000_000_000 + ns` (nanoseconds don't really make any difference since the tables are run-based).

### Limitations

Exceptions have been observed when calling `chanStatus.BadChannels()`. The `cppyy` interface obscures the details of this `std::exception` and I could not easily track the issue down; however, an ugly workaround can be implemented by querying all the TPC channels one by one in a loop.